### PR TITLE
[IMP] dms: add migration script for muk_dms

### DIFF
--- a/dms/migrations/13.0.1/post-migration.py
+++ b/dms/migrations/13.0.1/post-migration.py
@@ -1,0 +1,9 @@
+# Copyright 2020 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade  # pylint: disable=W7936
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    env["dms.directory"].search([])._compute_complete_name()

--- a/dms/migrations/13.0.1/post-migration.py
+++ b/dms/migrations/13.0.1/post-migration.py
@@ -1,9 +1,29 @@
 # Copyright 2020 Creu Blanca
+# Copyright 2020 ForgeFlow S.L.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openupgradelib import openupgrade  # pylint: disable=W7936
 
 
+def recompute_file_content(env):
+    for file in env["dms.file"].search([]):
+        if "." in file.extension:
+            file.extension = file.extension.replace(".", "")
+        try:
+            file.content
+        except Exception:
+            env.cr.execute("SELECT reference FROM dms_file where id = %s", (file.id,))
+            result = env.cr.fetchone()
+            reference_id = int(result[0].split(",")[1])
+            env.cr.execute(
+                "SELECT data FROM muk_dms_data_database where id = %s", (reference_id,)
+            )
+            content = env.cr.fetchone()
+            file.content = content[0]
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     env["dms.directory"].search([])._compute_complete_name()
+    if version < "12.0.2.0.0":
+        recompute_file_content(env)

--- a/dms/migrations/13.0.1/pre-migration.py
+++ b/dms/migrations/13.0.1/pre-migration.py
@@ -1,0 +1,89 @@
+# Copyright 2020 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade  # pylint: disable=W7936
+
+_model_renames = [
+    ("muk_dms.file", "dms.file"),
+    ("muk_dms.category", "dms.category"),
+    ("muk_dms.tag", "dms.tag"),
+    ("muk_dms.directory", "dms.directory"),
+    ("muk_dms.storage", "dms.storage"),
+    ("muk_dms.mixins.thumbnail", "dms.mixins.thumbnail"),
+    ("muk_security.access_groups", "dms.access.group"),
+]
+
+_table_renames = [
+    ("muk_dms_file", "dms_file"),
+    ("muk_dms_category", "dms_category"),
+    ("muk_dms_tag", "dms_tag"),
+    ("muk_dms_directory", "dms_directory"),
+    ("muk_dms_storage", "dms_storage"),
+    ("muk_dms_file_tag_rel", "dms_file_tag_rel"),
+    ("muk_dms_directory_tag_rel", "dms_directory_tag_rel"),
+    ("muk_dms_directory_star_rel", "dms_directory_star_rel"),
+    ("muk_security_access_groups", "dms_access_group"),
+    # Security Mixin relation tables
+    ("muk_dms_directory_groups_rel", "dms_directory_groups_rel"),
+    ("muk_dms_directory_complete_groups_rel", "dms_directory_complete_groups_rel"),
+]
+
+_field_renames = [
+    ("dms.category", "dms_category", "parent_category", "parent_id"),
+    ("dms.category", "dms_category", "child_categories", "child_category_ids"),
+    ("dms.category", "dms_category", "tags", "tag_ids"),
+    ("dms.category", "dms_category", "directories", "directory_ids"),
+    ("dms.category", "dms_category", "files", "file_ids"),
+    ("dms.directory", "dms_directory", "root_storage", "root_storage_id"),
+    ("dms.directory", "dms_directory", "storage", "storage_id"),
+    ("dms.directory", "dms_directory", "parent_directory", "parent_id"),
+    ("dms.directory", "dms_directory", "company", "company_id"),
+    ("dms.directory", "dms_directory", "category", "category_id"),
+    ("dms.directory", "dms_directory", "child_directories", "child_directory_ids"),
+    ("dms.directory", "dms_directory", "tags", "tag_ids"),
+    ("dms.directory", "dms_directory", "user_stars", "user_star_ids"),
+    ("dms.directory", "dms_directory", "files", "file_ids"),
+    ("dms.directory", "dms_directory", "groups", "group_ids"),
+    ("dms.directory", "dms_directory", "complete_groups", "complete_group_ids"),
+    ("dms.tag", "dms_tag", "category", "category_id"),
+    ("dms.file", "dms_file", "directory", "directory_id"),
+    ("dms.file", "dms_file", "storage", "storage_id"),
+    ("dms.file", "dms_file", "company", "company_id"),
+    ("dms.file", "dms_file", "category", "category_id"),
+    ("dms.file", "dms_file", "tags", "tag_ids"),
+    ("dms.file", "dms_file", "groups", "group_ids"),
+    ("dms.file", "dms_file", "complete_groups", "complete_group_ids"),
+    ("dms.file", "dms_file", "mimetype", "res_mimetype"),
+    ("dms.storage", "dms_storage", "root_directories", "root_directory_ids"),
+    ("dms.storage", "dms_storage", "storage_directories", "storage_directory_ids"),
+    ("dms.storage", "dms_storage", "company", "company_id"),
+    ("dms.storage", "dms_storage", "storage_files", "storage_file_ids"),
+    ("dms.access.group", "dms_access_group", "directories", "directory_ids"),
+    ("dms.access.group", "dms_access_group", "parent_group", "parent_group_id"),
+    ("dms.access.group", "dms_access_group", "child_groups", "child_group_ids"),
+    ("dms.access.group", "dms_access_group", "groups", "group_ids"),
+    ("dms.access.group", "dms_access_group", "explicit_users", "explicit_user_ids"),
+    ("dms.access.group", "dms_access_group", "users", "user_ids"),
+]
+
+# Complete name must be added manually due to its usage as order
+_field_add = [("complete_name", "dms.directory", "dms_directory", "char", False, "dms")]
+
+_config_parameters = {
+    "muk_dms.forbidden_extensions": "dms.forbidden_extensions",
+    "muk_web_utils.binary_max_size": "dms.binary_max_size",
+}
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    cr = env.cr
+    if openupgrade.table_exists(cr, "muk_dms_file"):
+        openupgrade.rename_models(cr, _model_renames)
+        openupgrade.rename_tables(cr, _table_renames)
+        openupgrade.rename_fields(env, _field_renames)
+        openupgrade.add_fields(env, _field_add)
+        for key in _config_parameters:
+            env["ir.config_parameter"].search([("key", "=", key)]).write(
+                {"key": _config_parameters[key]}
+            )


### PR DESCRIPTION
Migration script used to migrate muk_dms to dms.

Tested with OpenUpgrade adding a rename from muk_dms to dms on `apriori.py`