### PR TITLE
[FIX] dms: Download file with its proper name

### DIFF
--- a/dms/static/src/js/views/file_kanban_controller.js
+++ b/dms/static/src/js/views/file_kanban_controller.js
@@ -51,7 +51,7 @@ odoo.define("dms.FileKanbanController", function(require) {
                         "/" +
                         fieldName +
                         "/" +
-                        "datas" +
+                        record.data.name +
                         "?download=true";
                 }
             },


### PR DESCRIPTION
This PR fixes the following issue:
https://github.com/OCA/dms/pull/7#issuecomment-672705868