### PR TITLE
[FIX] dms: fix wrong test

### DIFF
--- a/dms/tests/test_directory.py
+++ b/dms/tests/test_directory.py
@@ -11,7 +11,7 @@ class DirectoryTestCase(DocumentsBaseCase):
         self.directory_root_demo_01 = self.browse_ref("dms.directory_01_demo")
         self.directory_root_demo_02 = self.browse_ref("dms.directory_02_demo")
         self.directory_root_demo_03 = self.browse_ref("dms.directory_11_demo")
-        self.directory_sub_demo_01 = self.browse_ref("dms.directory_03_demo")
+        self.directory_sub_demo_01 = self.browse_ref("dms.directory_04_demo")
         self.directory_sub_demo_02 = self.browse_ref("dms.directory_12_demo")
         self.new_storage = self.create_storage(sudo=True)
 
@@ -36,7 +36,7 @@ class DirectoryTestCase(DocumentsBaseCase):
             self.directory_root_demo_03.count_files, copy_root_directory.count_files
         )
 
-    @multi_users(lambda self: self.multi_users(demo=False), callback="_setup_test_data")
+    @multi_users(lambda self: self.multi_users(), callback="_setup_test_data")
     def test_copy_sub_directory(self):
         copy_sub_directory = self.directory_sub_demo_01.copy()
         self.assertEqual(


### PR DESCRIPTION

In v13, this test is programmed in such a way that the demo user is supposed to be able to copy that subdirectory: https://github.com/OCA/dms/blob/c3f802db43362127e70d8c7b4987fb71d4c1f01c/dms/tests/test_directory.py#L40

However, in https://github.com/OCA/dms/pull/7 that test was modified indicating that demo user didn't have permissions to do that: https://github.com/OCA/dms/blob/e3b6d8d24534f2a68bfb88e310cc70cefe46bb64/dms/tests/test_directory.py#L39

Rolling back that change to ensure premissions remain the same in both versions of the module.


In our downstream CI, that test (v12) is failing (which actually means that the test is passing when it was expected to fail) with these logs:

<details>

```
2020-09-23 09:05:38,705 40 INFO prod odoo.addons.dms.tests.common: Test (test_copy_sub_directory) with user (6) failed! 
2020-09-23 09:05:38,706 40 ERROR prod odoo.addons.dms.tests.test_directory: ERROR 
...
2020-09-23 09:05:40,957 40 INFO prod odoo.addons.dms.tests.test_directory: ====================================================================== 
2020-09-23 09:05:40,957 40 ERROR prod odoo.addons.dms.tests.test_directory: ERROR: test_copy_sub_directory (odoo.addons.dms.tests.test_directory.DirectoryTestCase) 
2020-09-23 09:05:40,957 40 ERROR prod odoo.addons.dms.tests.test_directory: Traceback (most recent call last): 
2020-09-23 09:05:40,957 40 ERROR prod odoo.addons.dms.tests.test_directory: `   File "/opt/odoo/auto/addons/dms/tests/common.py", line 83, in wrapper 
2020-09-23 09:05:40,957 40 ERROR prod odoo.addons.dms.tests.test_directory: `     raise Exception(_("Error has not been raised")) 
2020-09-23 09:05:40,957 40 ERROR prod odoo.addons.dms.tests.test_directory: ` Exception: Error has not been raised 
2020-09-23 09:05:40,957 40 INFO prod odoo.addons.dms.tests.test_directory: Ran 18 tests in 3.973s 
2020-09-23 09:05:40,957 40 ERROR prod odoo.addons.dms.tests.test_directory: FAILED 
2020-09-23 09:05:40,957 40 INFO prod odoo.addons.dms.tests.test_directory:  (errors=1) 
2020-09-23 09:05:40,957 40 ERROR prod odoo.modules.module: Module dms: 0 failures, 1 errors 
...
2020-09-23 09:05:42,329 40 INFO prod odoo.addons.dms.tests.common: Test (test_copy_sub_directory) with user (6) failed! 
2020-09-23 09:05:42,335 40 ERROR prod odoo.addons.dms.tests.test_directory_mail: ERROR 
...
2020-09-23 09:05:46,501 40 INFO prod odoo.addons.dms.tests.common: Test (test_copy_sub_directory) with user (6) failed! 
2020-09-23 09:05:46,502 40 ERROR prod odoo.addons.dms.tests.test_directory_mail: ERROR 
...
2020-09-23 09:05:48,867 40 INFO prod odoo.addons.dms.tests.test_directory_mail: ====================================================================== 
2020-09-23 09:05:48,867 40 ERROR prod odoo.addons.dms.tests.test_directory_mail: ERROR: test_copy_sub_directory (odoo.addons.dms.tests.test_directory_mail.DirectoryActionTestCase) 
2020-09-23 09:05:48,867 40 ERROR prod odoo.addons.dms.tests.test_directory_mail: Traceback (most recent call last): 
2020-09-23 09:05:48,867 40 ERROR prod odoo.addons.dms.tests.test_directory_mail: `   File "/opt/odoo/auto/addons/dms/tests/common.py", line 83, in wrapper 
2020-09-23 09:05:48,867 40 ERROR prod odoo.addons.dms.tests.test_directory_mail: `     raise Exception(_("Error has not been raised")) 
2020-09-23 09:05:48,867 40 ERROR prod odoo.addons.dms.tests.test_directory_mail: ` Exception: Error has not been raised 
2020-09-23 09:05:48,867 40 INFO prod odoo.addons.dms.tests.test_directory_mail: ====================================================================== 
2020-09-23 09:05:48,868 40 ERROR prod odoo.addons.dms.tests.test_directory_mail: ERROR: test_copy_sub_directory (odoo.addons.dms.tests.test_directory.DirectoryTestCase) 
2020-09-23 09:05:48,868 40 ERROR prod odoo.addons.dms.tests.test_directory_mail: Traceback (most recent call last): 
2020-09-23 09:05:48,868 40 ERROR prod odoo.addons.dms.tests.test_directory_mail: `   File "/opt/odoo/auto/addons/dms/tests/common.py", line 83, in wrapper 
2020-09-23 09:05:48,868 40 ERROR prod odoo.addons.dms.tests.test_directory_mail: `     raise Exception(_("Error has not been raised")) 
2020-09-23 09:05:48,868 40 ERROR prod odoo.addons.dms.tests.test_directory_mail: ` Exception: Error has not been raised 
2020-09-23 09:05:48,868 40 INFO prod odoo.addons.dms.tests.test_directory_mail: Ran 38 tests in 7.909s 
2020-09-23 09:05:48,868 40 ERROR prod odoo.addons.dms.tests.test_directory_mail: FAILED 
2020-09-23 09:05:48,868 40 INFO prod odoo.addons.dms.tests.test_directory_mail:  (errors=2) 
2020-09-23 09:05:48,868 40 INFO prod odoo.modules.module: odoo.addons.dms.tests.test_directory_mail tested in 7.91s, 15111 queries 
2020-09-23 09:05:48,868 40 ERROR prod odoo.modules.module: Module dms: 0 failures, 2 errors 
```

</details>

@Tecnativa TT25645