### PR TITLE
[12.0] [IMP] dms: Attachment Integration

### DIFF
--- a/dms/models/__init__.py
+++ b/dms/models/__init__.py
@@ -11,3 +11,4 @@ from . import tag
 
 from . import res_company
 from . import res_config_settings
+from . import ir_attachment

--- a/dms/models/directory.py
+++ b/dms/models/directory.py
@@ -271,6 +271,9 @@ class DmsDirectory(models.Model):
         if self.env.user.has_group("base.group_public"):
             res = True
         return res
+    record_ref = fields.Reference(
+        string="Record Referenced", selection="_select_reference", readonly=True,
+    )
 
     @api.model
     def _search_is_hidden(self, operator, value):
@@ -654,3 +657,7 @@ class DmsDirectory(models.Model):
                 DmsDirectory, self.sudo().search([("id", "child_of", self.ids)])
             ).unlink()
         return super().unlink()
+
+    def _select_reference(self):
+        model_ids = self.env["ir.model"].search([])
+        return [(r["model"], r["name"]) for r in model_ids] + [("", "")]

--- a/dms/models/ir_attachment.py
+++ b/dms/models/ir_attachment.py
@@ -1,0 +1,85 @@
+import re
+
+from odoo import api, models
+
+
+class IrAttachment(models.Model):
+
+    _inherit = "ir.attachment"
+
+    def _dms_file_name(self, directory_id, file_name):
+        count = 1
+        for file in directory_id.file_ids:
+
+            dms_file_name = re.sub(r" \([0-9]*\)", "", file.name)
+            if dms_file_name == file_name:
+                count += 1
+
+        file, ext = re.split(r"\.", file_name)
+        return file + " ({}).".format(count) + ext if count > 1 else file_name
+
+    def _create_record_dir(self, storage_id, attachment_id):
+        dms_field = self.env["ir.module.module"].search([("name", "=", "dms_field")])
+
+        directory_fields = {
+            "name": attachment_id.res_name.replace("/", "-"),
+            "is_root_directory": True,
+            "parent_id": False,
+            "root_storage_id": storage_id.id,
+        }
+
+        if dms_field and dms_field.state == "installed":
+            directory_fields["res_id"] = attachment_id.res_id
+
+        return self.env["dms.directory"].create(directory_fields)
+
+    @api.model
+    def create(self, vals):
+        if "dms_file" in vals and vals["dms_file"]:
+            del vals["dms_file"]
+            return super(IrAttachment, self).create(vals)
+        else:
+            attachment_id = super(IrAttachment, self).create(vals)
+            if "res_model" in vals:
+                storage_id = self.env["dms.storage"].search(
+                    [("model_id", "=", vals["res_model"])]
+                )
+
+                if storage_id and storage_id.save_type == "attachment":
+                    record_directory = self.env["dms.directory"].search(
+                        [("complete_name", "=", attachment_id.res_name)]
+                    )
+                    if not record_directory:
+                        record_directory = self._create_record_dir(
+                            storage_id, attachment_id
+                        )
+
+                    attachments_dir_id = record_directory.child_directory_ids.filtered(
+                        lambda r: r.name == "Attachments"
+                    )
+
+                    if not attachments_dir_id:
+                        attachments_dir_id = self.env["dms.directory"].create(
+                            {
+                                "name": "Attachments",
+                                "parent_id": record_directory.id,
+                                "storage_id": storage_id.id,
+                                "record_ref": "{},{}".format(
+                                    attachment_id.res_model, attachment_id.res_id
+                                ),
+                            }
+                        )
+                    file_name = self._dms_file_name(attachments_dir_id, vals["name"])
+
+                    self.env["dms.file"].create(
+                        {
+                            "name": file_name,
+                            "directory_id": attachments_dir_id.id,
+                            "attachment_id": attachment_id.id,
+                            "record_ref": "{},{}".format(
+                                attachment_id.res_model, attachment_id.res_id
+                            ),
+                        }
+                    )
+
+            return attachment_id

--- a/dms/models/storage.py
+++ b/dms/models/storage.py
@@ -84,7 +84,7 @@ class Storage(models.Model):
         compute="_compute_count_storage_files", string="Count Files"
     )
 
-    model_id = fields.Many2one("ir.model", auto_join=True)
+    model_ids = fields.Many2many("ir.model", string="Linked Models")
 
     # ----------------------------------------------------------
     # Actions

--- a/dms/models/storage.py
+++ b/dms/models/storage.py
@@ -22,7 +22,11 @@ class Storage(models.Model):
     name = fields.Char(string="Name", required=True)
 
     save_type = fields.Selection(
-        selection=[("database", _("Database")), ("file", _("Filestore"))],
+        selection=[
+            ("database", _("Database")),
+            ("file", _("Filestore")),
+            ("attachment", _("Attachment")),
+        ],
         string="Save Type",
         default="database",
         required=True,
@@ -79,6 +83,8 @@ class Storage(models.Model):
     count_storage_files = fields.Integer(
         compute="_compute_count_storage_files", string="Count Files"
     )
+
+    model_id = fields.Many2one("ir.model", auto_join=True)
 
     # ----------------------------------------------------------
     # Actions

--- a/dms/readme/ROADMAP.rst
+++ b/dms/readme/ROADMAP.rst
@@ -1,3 +1,5 @@
 - Files preview in portal
 - Allow to download folder in portal and create zip file with all content
 - Save in cache own_root directories and update in every create/write/unlink function
+- Add a migration procedure for converting an storage to attachment one for populating existing records with attachments as folders
+- Add a link from attachment view in chatter to linked documents

--- a/dms/tests/common.py
+++ b/dms/tests/common.py
@@ -154,6 +154,7 @@ class DocumentsBaseCase(common.TransactionCase):
         self.file = self.env["dms.file"]
         self.category = self.env["dms.category"]
         self.tag = self.env["dms.tag"]
+        self.attachment = self.env["ir.attachment"]
 
     def _setup_test_data(self):
         self.storage = self.storage.sudo(self.env.uid)
@@ -161,6 +162,7 @@ class DocumentsBaseCase(common.TransactionCase):
         self.file = self.file.sudo(self.env.uid)
         self.category = self.category.sudo(self.env.uid)
         self.tag = self.tag.sudo(self.env.uid)
+        self.attachment = self.attachment.sudo(self.env.uid)
 
     def _load(self, module, *args):
         convert_file(
@@ -217,5 +219,32 @@ class DocumentsBaseCase(common.TransactionCase):
                 "name": uuid.uuid4().hex,
                 "directory_id": directory.id,
                 "content": content or self.content_base64(),
+            }
+        )
+
+    def create_file_with_context(
+        self, context, directory=False, content=False, storage=False, sudo=False
+    ):
+        model = self.file.sudo() if sudo else self.file
+        if not directory:
+            directory = self.create_directory(storage=storage, sudo=sudo)
+        return model.with_context(context).create(
+            {
+                "name": uuid.uuid4().hex,
+                "directory_id": directory.id,
+                "content": content or self.content_base64(),
+            }
+        )
+
+    def create_attachment(
+        self, name, res_model=False, res_id=False, content=False, sudo=False
+    ):
+        model = self.attachment.sudo() if sudo else self.attachment
+        return model.create(
+            {
+                "name": name,
+                "res_model": res_model,
+                "res_id": res_id,
+                "datas": content or self.content_base64(),
             }
         )

--- a/dms/tests/test_storage.py
+++ b/dms/tests/test_storage.py
@@ -8,6 +8,42 @@ from .test_storage_database import StorageTestCase
 
 class StorageLObjectTestCase(StorageTestCase):
     @multi_users(lambda self: self.multi_users(demo=False), callback="_setup_test_data")
+    def test_storage_attachment(self):
+        model_res_partner = self.browse_ref("base.model_res_partner")
+        res_partner_1 = self.browse_ref("base.res_partner_1").id
+        storage = self.create_storage(sudo=False).sudo(self.uid)
+        storage.write(
+            {"save_type": "attachment", "model_ids": [(4, model_res_partner.id)]}
+        )
+        root_directory = self.create_directory(storage=storage, sudo=False).sudo(
+            self.uid
+        )
+        root_directory.model_id = model_res_partner.id
+        self.assertEqual(root_directory.res_model, model_res_partner.model)
+        self.create_attachment(
+            name="demo.txt",
+            res_model=model_res_partner.model,
+            res_id=res_partner_1,
+            sudo=False,
+        ).sudo(self.uid)
+        directory_ids = self.directory.sudo(self.uid).search(
+            [
+                ("storage_id", "=", storage.id),
+                ("res_model", "=", model_res_partner.model),
+                ("res_id", "=", res_partner_1),
+            ]
+        )
+        for directory_id in directory_ids:
+            file_01 = self.create_file_with_context(
+                context={"default_directory_id": directory_id.id},
+                storage=directory_id.storage_id,
+            ).sudo(self.uid)
+            self.assertEqual(file_01.storage_id, storage)
+            self.assertEqual(file_01.storage_id.save_type, "attachment")
+            self.assertEqual(file_01.save_type, "file")
+            self.assertEqual(storage.count_storage_files, 2)
+
+    @multi_users(lambda self: self.multi_users(demo=False), callback="_setup_test_data")
     def test_file_migrate(self):
         storage = self.create_storage(sudo=False).sudo(self.uid)
         file_01 = self.create_file(storage=storage)
@@ -37,3 +73,18 @@ class StorageLObjectTestCase(StorageTestCase):
         self.assertEqual(file_02.storage_id, storage)
         self.assertEqual(file_02.storage_id.save_type, "database")
         self.assertEqual(file_02.save_type, "database")
+        storage.write({"save_type": "attachment"})
+        file_03 = self.create_file(storage=storage)
+        self.assertEqual(file_02.storage_id, storage)
+        self.assertEqual(file_02.storage_id.save_type, "attachment")
+        self.assertEqual(file_02.save_type, "database")
+        self.assertEqual(file_03.storage_id, storage)
+        self.assertEqual(file_03.storage_id.save_type, "attachment")
+        self.assertEqual(file_03.save_type, "file")
+        storage.action_storage_migrate()
+        self.assertEqual(file_02.storage_id, storage)
+        self.assertEqual(file_02.storage_id.save_type, "attachment")
+        self.assertEqual(file_02.save_type, "file")
+        self.assertEqual(file_03.storage_id, storage)
+        self.assertEqual(file_03.storage_id.save_type, "attachment")
+        self.assertEqual(file_03.save_type, "file")

--- a/dms/views/directory.xml
+++ b/dms/views/directory.xml
@@ -480,9 +480,20 @@
                         </group>
                     </group>
                     <group>
+                        <field name="storage_id_save_type" invisible="True" />
+                        <field name="allowed_model_ids" invisible="True" />
+                        <field
+                            name="model_id"
+                            attrs="{'invisible': [('storage_id_save_type', '!=', 'attachment')], 'readonly': [('count_total_files', '>', 0)]}"
+                        />
+                        <field
+                            name="res_id"
+                            readonly="True"
+                            attrs="{'invisible': [('storage_id_save_type', '!=', 'attachment')]}"
+                        />
                         <field
                             name="record_ref"
-                            attrs="{'invisible': [('file_ids', '=', [])]}"
+                            attrs="{'invisible': [('storage_id_save_type', '!=', 'attachment')]}"
                         />
                     </group>
                     <notebook>

--- a/dms/views/directory.xml
+++ b/dms/views/directory.xml
@@ -479,6 +479,12 @@
                             <field name="starred" widget="boolean_favorite" />
                         </group>
                     </group>
+                    <group>
+                        <field
+                            name="record_ref"
+                            attrs="{'invisible': [('file_ids', '=', [])]}"
+                        />
+                    </group>
                     <notebook>
                         <page name="page_directories" string="Subdirectories">
                             <field

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -416,6 +416,9 @@
                             />
                         </group>
                     </group>
+                    <group>
+                        <field name="record_ref" />
+                    </group>
                     <notebook>
                         <page name="page_meta" string="Meta Information">
                             <group>

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -417,7 +417,21 @@
                         </group>
                     </group>
                     <group>
-                        <field name="record_ref" />
+                        <field name="storage_id_save_type" invisible="True" />
+                        <field
+                            name="res_model"
+                            readonly="True"
+                            attrs="{'invisible': [('storage_id_save_type', '!=', 'attachment')]}"
+                        />
+                        <field
+                            name="res_id"
+                            readonly="True"
+                            attrs="{'invisible': [('storage_id_save_type', '!=', 'attachment')]}"
+                        />
+                        <field
+                            name="record_ref"
+                            attrs="{'invisible': [('storage_id_save_type', '!=', 'attachment')]}"
+                        />
                     </group>
                     <notebook>
                         <page name="page_meta" string="Meta Information">

--- a/dms/views/storage.xml
+++ b/dms/views/storage.xml
@@ -169,6 +169,10 @@
                         </group>
                         <group>
                             <field name="company_id" />
+                            <field
+                                name="model_id"
+                                attrs="{'readonly': [('count_storage_directories', '>', 0)]}"
+                            />
                         </group>
                     </group>
                     <notebook>

--- a/dms/views/storage.xml
+++ b/dms/views/storage.xml
@@ -170,8 +170,8 @@
                         <group>
                             <field name="company_id" />
                             <field
-                                name="model_id"
-                                attrs="{'readonly': [('count_storage_directories', '>', 0)]}"
+                                name="model_ids"
+                                attrs="{'invisible': [('save_type', '!=', 'attachment')]}"
                             />
                         </group>
                     </group>


### PR DESCRIPTION
This feature aims to integrate dms with ir.attachment. That way, every time a new attachment is created, a dms.file is also created with a category according to the model the attachment is in.

Related to (V13): https://github.com/OCA/dms/pull/9

Please @pedrobaeza review it

@Tecnativa TT25646