### PR TITLE
[12.0][FIX] dms: Fix mimetype error in some files (.xlsx for example)

### DIFF
--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -6,7 +6,6 @@ import base64
 import hashlib
 import json
 import logging
-import mimetypes
 from collections import defaultdict
 
 from odoo import SUPERUSER_ID, _, api, fields, models, tools
@@ -387,11 +386,10 @@ class File(models.Model):
     @api.depends("name", "content")
     def _compute_mimetype(self):
         for record in self:
-            mimetype = record.name and mimetypes.guess_type(record.name)[0]
-            if not mimetype and record.content:
-                binary = base64.b64decode(record.with_context({}).content or "")
-                mimetype = guess_mimetype(binary, default="application/octet-stream")
-            record.res_mimetype = mimetype
+            binary = base64.b64decode(record.with_context({}).content or "")
+            record.res_mimetype = guess_mimetype(
+                binary, default="application/octet-stream"
+            )
 
     @api.depends("content_binary", "content_file")
     def _compute_content(self):


### PR DESCRIPTION
In some case, if upload some extension type (.xlsx for example), in some operations (when update "_Inherit groups_" directory) error appear related to not defined mimetype.

Simplifying `_compute_mimetype` function is the option to solve it.

Related PR (V13): https://github.com/OCA/dms/pull/35

Please @pedrobaeza review it

@Tecnativa TT26273

