### PR TITLE
[12.0][FIX] dms: Filter only type=binary in ir_attachment to create dms_file

### DIFF
--- a/dms/__manifest__.py
+++ b/dms/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Document Management System",
     "summary": """Document Management System for Odoo""",
-    "version": "12.0.4.0.1",
+    "version": "12.0.4.0.2",
     "category": "Document Management",
     "license": "LGPL-3",
     "website": "http://github.com/OCA/dms",

--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -655,6 +655,7 @@ class File(models.Model):
                         "datas": vals["content"],
                         "res_model": directory.res_model,
                         "res_id": directory.res_id,
+                        "type": "binary",
                     }
                 )
             )

--- a/dms/models/ir_attachment.py
+++ b/dms/models/ir_attachment.py
@@ -31,7 +31,11 @@ class IrAttachment(models.Model):
 
     def _dms_operations(self):
         for attachment in self:
-            if not attachment.res_model or not attachment.res_id:
+            if (
+                attachment.type != "binary"
+                or not attachment.res_model
+                or not attachment.res_id
+            ):
                 continue
             directories = self._get_dms_directories(
                 attachment.res_model, attachment.res_id


### PR DESCRIPTION
Add type=binary when `ir_attachment` is auto-create (relate to `dms_file` create).
Only auto-create `dms_file` if `ir_attachment` related is type=binary

Please @pedrobaeza, @etobella review it

@Tecnativa TT19733