### PR TITLE
[12.0][FIX] dms: Fix error when  web_drop_target addon used to create new file + remove content field in tree

### DIFF
--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -644,7 +644,12 @@ class File(models.Model):
 
     def _create_model_attachment(self, vals):
         res_vals = vals.copy()
-        directory = self.env["dms.directory"].sudo().browse(res_vals["directory_id"])
+        directory = False
+        directory_model = self.env["dms.directory"]
+        if "directory_id" in res_vals:
+            directory = directory_model.browse(res_vals["directory_id"])
+        elif self.env.context.get("active_id"):
+            directory = directory_model.browse(self.env.context.get("active_id"))
         if directory and directory.res_model and directory.res_id:
             attachment = (
                 self.env["ir.attachment"]

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -298,7 +298,7 @@
                 <field name="is_lock_editor" invisible="1" />
                 <field name="name" />
                 <field name="write_date" />
-                <field name="content" />
+                <field name="size"/>
                 <field name="res_mimetype" />
                 <field name="path_names" widget="path_names" string="Path" />
             </tree>


### PR DESCRIPTION
1- Fix error when  `web_drop_target` addon used to create new file

![dms-error-web_drop_target](https://user-images.githubusercontent.com/4117568/106433560-a8709f80-6470-11eb-9077-c3949f53f25d.gif)

2- Remove `content` field in tree view to prevent download all files.

This error also happens in 13.0

Please @pedrobaeza , @joao-p-marques  and @Yajo review it.

@Tecnativa TT28040