### PR TITLE
[13.0][FIX] dms: Fix error when web_drop_target addon used to create new file + remove content field in tree

### DIFF
--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -638,7 +638,12 @@ class File(models.Model):
 
     def _create_model_attachment(self, vals):
         res_vals = vals.copy()
-        directory = self.env["dms.directory"].sudo().browse(res_vals["directory_id"])
+        directory = False
+        directory_model = self.env["dms.directory"]
+        if "directory_id" in res_vals:
+            directory = directory_model.browse(res_vals["directory_id"])
+        elif self.env.context.get("active_id"):
+            directory = directory_model.browse(self.env.context.get("active_id"))
         if directory and directory.res_model and directory.res_id:
             attachment = (
                 self.env["ir.attachment"]

--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -638,13 +638,9 @@ class File(models.Model):
 
     def _create_model_attachment(self, vals):
         res_vals = vals.copy()
-        directory = False
-        directory_model = self.env["dms.directory"]
-        if "directory_id" in res_vals:
-            directory = directory_model.browse(res_vals["directory_id"])
-        elif self.env.context.get("active_id"):
-            directory = directory_model.browse(self.env.context.get("active_id"))
-        if directory and directory.res_model and directory.res_id:
+        directory_id = res_vals.get("directory_id", self.env.context.get("active_id"))
+        directory = self.env["dms.directory"].browse(directory_id)
+        if directory.res_model and directory.res_id:
             attachment = (
                 self.env["ir.attachment"]
                 .with_context(dms_file=True)

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -298,7 +298,7 @@
                 <field name="is_lock_editor" invisible="1" />
                 <field name="name" />
                 <field name="write_date" />
-                <field name="size"/>
+                <field name="size" />
                 <field name="res_mimetype" />
                 <field name="path_names" widget="path_names" string="Path" />
             </tree>

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -298,7 +298,7 @@
                 <field name="is_lock_editor" invisible="1" />
                 <field name="name" />
                 <field name="write_date" />
-                <field name="content" />
+                <field name="size"/>
                 <field name="res_mimetype" />
                 <field name="path_names" widget="path_names" string="Path" />
             </tree>


### PR DESCRIPTION
Related to 12.0: https://github.com/OCA/dms/pull/51

1- Fix error when  `web_drop_target` addon used to create new file

![dms-error-web_drop_target](https://user-images.githubusercontent.com/4117568/106433560-a8709f80-6470-11eb-9077-c3949f53f25d.gif)

2- Remove `content` field in tree view to prevent download all files.

@Tecnativa TT28040