### PR TITLE
[12.0][FIX] dms: Remove category creation in kanban tag view to prevent error

### DIFF
--- a/dms/views/tag.xml
+++ b/dms/views/tag.xml
@@ -40,7 +40,8 @@
         <field name="arch" type="xml">
             <kanban
                 class="o_kanban_small_column o_emphasize_colors"
-                on_create="quick_create"
+                quick_create="true"
+                group_create="false"
             >
                 <field name="color" />
                 <templates>


### PR DESCRIPTION
Remove category creation in kanban tag view to prevent error

![dms-tag-error](https://user-images.githubusercontent.com/4117568/107515117-e4abaa80-6baa-11eb-8e93-9ca3b1ceda67.gif)

@Tecnativa TT28241