### PR TITLE
[13.0][FIX] dms: Use sudo() in attachment operacion to prevent error in attachment creation

### DIFF
--- a/dms/models/ir_attachment.py
+++ b/dms/models/ir_attachment.py
@@ -1,3 +1,4 @@
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 from odoo import api, models
 
@@ -12,13 +13,13 @@ class IrAttachment(models.Model):
         )
 
     def _dms_directories_create(self):
-        items = self._get_dms_directories(self.res_model, False)
+        items = self.sudo()._get_dms_directories(self.res_model, False)
         for item in items:
             model_item = self.env[self.res_model].sudo().browse(self.res_id)
             ir_model_item = self.env["ir.model"].search(
                 [("model", "=", self.res_model)]
             )
-            self.env["dms.directory"].create(
+            self.env["dms.directory"].sudo().create(
                 {
                     "name": model_item.display_name,
                     "model_id": ir_model_item.id,
@@ -33,18 +34,18 @@ class IrAttachment(models.Model):
         for attachment in self:
             if not attachment.res_model or not attachment.res_id:
                 continue
-            directories = self._get_dms_directories(
+            directories = self.sudo()._get_dms_directories(
                 attachment.res_model, attachment.res_id
             )
             if not directories:
                 attachment._dms_directories_create()
                 # Get dms_directories again (with items previously created)
-                directories = self._get_dms_directories(
+                directories = self.sudo()._get_dms_directories(
                     attachment.res_model, attachment.res_id
                 )
             # Auto-create_files
             for directory in directories:
-                self.env["dms.file"].create(
+                self.env["dms.file"].sudo().create(
                     {
                         "name": attachment.name,
                         "directory_id": directory.id,

--- a/dms/tests/__init__.py
+++ b/dms/tests/__init__.py
@@ -6,4 +6,5 @@ from . import test_file_database
 from . import test_file
 from . import test_benchmark
 from . import test_directory_mail
+from . import test_ir_attachment
 from . import test_portal

--- a/dms/tests/test_ir_attachment.py
+++ b/dms/tests/test_ir_attachment.py
@@ -1,0 +1,45 @@
+# Copyright 2021 Tecnativa - Víctor Martínez
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+import base64
+
+from odoo.tests import common
+
+
+class IrAttachmentTestCase(common.TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.user_demo = self.browse_ref("base.user_demo")
+        self.unprivileged_user = self.env["res.users"].create(
+            {
+                "name": "unprivileged test user",
+                "login": "test",
+                "groups_id": [
+                    (
+                        6,
+                        0,
+                        [
+                            self.env.ref("base.group_user").id,
+                            self.env.ref("base.group_partner_manager").id,
+                        ],
+                    )
+                ],
+            }
+        )
+        self.partner = self.env.ref("base.res_partner_12")
+        self.attachment = self.env["ir.attachment"]
+
+    def content_base64(self):
+        return base64.b64encode(b"\xff data")
+
+    def test_create_attachment(self):
+        vals = {
+            "name": "Test file",
+            "res_model": "res.partner",
+            "res_id": self.partner.id,
+            "datas": self.content_base64(),
+        }
+        attachment = self.attachment.sudo(self.user_demo).create(vals)
+        self.assertEquals(attachment.name, "Test file")
+        vals["name"] = "Test file 2"
+        attachment = self.attachment.sudo(self.unprivileged_user).create(vals)
+        self.assertEquals(attachment.name, "Test file 2")


### PR DESCRIPTION
Related to 12.0: https://github.com/OCA/dms/pull/53

**What happen?**
Permissions error because to user haven't access to dms models.

**When?**
If user without dms permissions try to create a attachment in any model. For example, try to email send with attachment(s).

**Why don't appear it until now?**
Probably because all people that use dms have dms permissions (user for example) or haven't create new attachment yet with users without dms permissions.

**Why?**
In attachment creation dms https://github.com/OCA/dms/blob/13.0/dms/models/ir_attachment.py#L57-L62 make some operations related to: search/create dms directories and search/create dms files (create if it's necessary according to dms configuration).

**But, why these functionality?**
DMS has the functionality of creating dms files and folders as attachments are created.
If a storage configured as attachment and related to a model is created (partner for example), a root directory is created in that storage linked to the partner model, when an attachment is created in a partner, it will be auto-created (if it does not exist ) the corresponding partner folder, and the dms file of that attachment will also be created in that folder. 

**And, it's really necessary to use `sudo()`?**
IMO yes, because the user who creates the attached file may not have the dms permissions and even if they did, they may not have access to the directories in which the dms file must be created (according to what is defined in dms access group). 

@Tecnativa TT28162