### PR TITLE
[13.0][REF+FIX] dms: Record_ref fixed when access to item (directory or file) in view

### DIFF
--- a/dms/models/__init__.py
+++ b/dms/models/__init__.py
@@ -1,6 +1,7 @@
 from . import access_groups
 from . import mixins_thumbnail
 from . import dms_security_mixin
+from . import abstract_dms_mixin
 
 from . import storage
 from . import directory

--- a/dms/models/abstract_dms_mixin.py
+++ b/dms/models/abstract_dms_mixin.py
@@ -1,0 +1,50 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models
+
+
+class AbstractDmsMixin(models.AbstractModel):
+    _name = "abstract.dms.mixin"
+    _description = "Abstract Dms Mixin"
+
+    name = fields.Char(string="Name", required=True, index=True)
+    res_model = fields.Char(string="Linked attachments model")
+    res_id = fields.Integer(string="Linked attachments record ID")
+    record_ref = fields.Reference(
+        string="Record Referenced",
+        compute="_compute_record_ref",
+        selection=lambda self: self._get_ref_selection(),
+    )
+    # Only defined to prevent error in other fields that related it
+    storage_id = fields.Many2one(
+        comodel_name="dms.storage", string="Storage", store=True,
+    )
+    is_hidden = fields.Boolean(
+        string="Storage is Hidden", related="storage_id.is_hidden", readonly=True
+    )
+    company_id = fields.Many2one(
+        related="storage_id.company_id",
+        comodel_name="res.company",
+        string="Company",
+        readonly=True,
+        store=True,
+        index=True,
+    )
+    color = fields.Integer(string="Color", default=0)
+    category_id = fields.Many2one(
+        comodel_name="dms.category",
+        context="{'dms_category_show_path': True}",
+        string="Category",
+    )
+
+    @api.model
+    def _get_ref_selection(self):
+        models = self.env["ir.model"].search([])
+        return [(model.model, model.name) for model in models]
+
+    @api.depends("res_model", "res_id")
+    def _compute_record_ref(self):
+        for record in self:
+            record.record_ref = False
+            if record.res_model and record.res_id:
+                record.record_ref = "{},{}".format(record.res_model, record.res_id)

--- a/dms/models/directory.py
+++ b/dms/models/directory.py
@@ -30,6 +30,7 @@ class DmsDirectory(models.Model):
         "mail.thread",
         "mail.activity.mixin",
         "mail.alias.mixin",
+        "abstract.dms.mixin",
     ]
 
     _rec_name = "complete_name"
@@ -37,8 +38,6 @@ class DmsDirectory(models.Model):
 
     _parent_store = True
     _parent_name = "parent_id"
-
-    name = fields.Char(string="Name", required=True, index=True)
 
     parent_path = fields.Char(index=True)
     is_root_directory = fields.Boolean(
@@ -58,7 +57,7 @@ class DmsDirectory(models.Model):
         readonly=False,
         copy=True,
     )
-
+    # Override acording to defined in AbstractDmsMixin
     storage_id = fields.Many2one(
         compute="_compute_storage",
         comodel_name="dms.storage",
@@ -90,25 +89,6 @@ class DmsDirectory(models.Model):
         string="Subdirectories",
         auto_join=False,
         copy=False,
-    )
-    is_hidden = fields.Boolean(
-        string="Storage is Hidden", related="storage_id.is_hidden", readonly=True
-    )
-    company_id = fields.Many2one(
-        related="storage_id.company_id",
-        comodel_name="res.company",
-        string="Company",
-        readonly=True,
-        store=True,
-        index=True,
-    )
-
-    color = fields.Integer(string="Color", default=0)
-
-    category_id = fields.Many2one(
-        comodel_name="dms.category",
-        context="{'dms_category_show_path': True}",
-        string="Category",
     )
 
     tag_ids = fields.Many2many(
@@ -291,11 +271,6 @@ class DmsDirectory(models.Model):
         string="Model",
         store=True,
     )
-    res_model = fields.Char(string="Linked attachments model")
-    res_id = fields.Integer(string="Linked attachments record ID")
-    record_ref = fields.Reference(
-        string="Record Referenced", compute="_compute_record_ref", selection=[]
-    )
     storage_id_save_type = fields.Selection(related="storage_id.save_type", store=False)
 
     @api.depends("root_storage_id", "storage_id")
@@ -320,13 +295,6 @@ class DmsDirectory(models.Model):
     def _inverse_model_id(self):
         for record in self:
             record.res_model = record.model_id.model
-
-    @api.depends("res_model", "res_id")
-    def _compute_record_ref(self):
-        for record in self:
-            record.record_ref = False
-            if record.res_model and record.res_id:
-                record.record_ref = "{},{}".format(record.res_model, record.res_id)
 
     @api.depends("name", "complete_name")
     def _compute_display_name(self):

--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -30,6 +30,7 @@ class File(models.Model):
         "dms.mixins.thumbnail",
         "mail.thread",
         "mail.activity.mixin",
+        "abstract.dms.mixin",
     ]
 
     _order = "name asc"
@@ -37,8 +38,6 @@ class File(models.Model):
     # ----------------------------------------------------------
     # Database
     # ----------------------------------------------------------
-
-    name = fields.Char(string="Filename", required=True, index=True)
 
     active = fields.Boolean(
         string="Archived",
@@ -56,7 +55,7 @@ class File(models.Model):
         required=True,
         index=True,
     )
-
+    # Override acording to defined in AbstractDmsMixin
     storage_id = fields.Many2one(
         related="directory_id.storage_id",
         comodel_name="dms.storage",
@@ -66,33 +65,12 @@ class File(models.Model):
         store=True,
     )
 
-    is_hidden = fields.Boolean(
-        string="Storage is Hidden", related="storage_id.is_hidden", readonly=True
-    )
-
-    company_id = fields.Many2one(
-        related="storage_id.company_id",
-        comodel_name="res.company",
-        string="Company",
-        readonly=True,
-        store=True,
-        index=True,
-    )
-
     path_names = fields.Char(
         compute="_compute_path", string="Path Names", readonly=True, store=False
     )
 
     path_json = fields.Text(
         compute="_compute_path", string="Path Json", readonly=True, store=False
-    )
-
-    color = fields.Integer(string="Color", default=0)
-
-    category_id = fields.Many2one(
-        comodel_name="dms.category",
-        context="{'dms_category_show_path': True}",
-        string="Category",
     )
 
     tag_ids = fields.Many2many(
@@ -184,23 +162,7 @@ class File(models.Model):
         invisible=True,
         ondelete="cascade",
     )
-    res_model = fields.Char(string="Linked attachments model")
-    res_id = fields.Integer(string="Linked attachments record ID")
-    record_ref = fields.Reference(
-        string="Record Referenced",
-        compute="_compute_record_ref",
-        selection=[],
-        readonly=True,
-        store=False,
-    )
     storage_id_save_type = fields.Selection(related="storage_id.save_type", store=False)
-
-    @api.depends("res_model", "res_id")
-    def _compute_record_ref(self):
-        for record in self:
-            record.record_ref = False
-            if record.res_model and record.res_id:
-                record.record_ref = "{},{}".format(record.res_model, record.res_id)
 
     def get_human_size(self):
         return human_size(self.size)


### PR DESCRIPTION
Related to https://github.com/OCA/dms/issues/60

- Refactor code to create `abstract.dms.mixin` to contain fields or functions that is used in some models (in these case some fields appear in directory and field and some functions about it).
- Fixed problem happen when access to file or folder view if record ref is set (file or folder has been created in attachment creation in partner for example)

Although it's work fine in 12.0 IMO it's necessary to apply 12.0 to standardize code.

@Tecnativa TT28337