### PR TITLE
[13.0][FIX] dms: Prevent parent_id error in directories in some UI cases

### DIFF
--- a/dms/__manifest__.py
+++ b/dms/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Document Management System",
     "summary": """Document Management System for Odoo""",
-    "version": "13.0.3.2.5",
+    "version": "13.0.4.0.0",
     "category": "Document Management",
     "license": "LGPL-3",
     "website": "http://github.com/OCA/dms",

--- a/dms/demo/directory.xml
+++ b/dms/demo/directory.xml
@@ -9,8 +9,9 @@
     <record id="directory_01_demo" model="dms.directory">
         <field name="name">Documents</field>
         <field name="is_root_directory" eval="True" />
+        <field name="parent_id" eval="False" />
         <field name="color" eval="1" />
-        <field name="root_storage_id" ref="dms.storage_demo" />
+        <field name="storage_id" ref="dms.storage_demo" />
         <field name="category_id" ref="dms.category_01_demo" />
         <field
             name="tag_ids"
@@ -24,8 +25,9 @@
     <record id="directory_02_demo" model="dms.directory">
         <field name="name">Media</field>
         <field name="is_root_directory" eval="True" />
+        <field name="parent_id" eval="False" />
         <field name="color" eval="2" />
-        <field name="root_storage_id" ref="dms.storage_demo" />
+        <field name="storage_id" ref="dms.storage_demo" />
         <field
             name="tag_ids"
             eval="[(6, 0, [ref('dms.tag_01_demo'), ref('dms.tag_03_demo')])]"
@@ -100,8 +102,9 @@
     <record id="directory_11_demo" model="dms.directory">
         <field name="name">Mails</field>
         <field name="is_root_directory" eval="True" />
+        <field name="parent_id" eval="False" />
         <field name="color" eval="3" />
-        <field name="root_storage_id" ref="dms.storage_demo" />
+        <field name="storage_id" ref="dms.storage_demo" />
         <field
             name="tag_ids"
             eval="[(6, 0, [ref('dms.tag_04_demo'), ref('dms.tag_05_demo')])]"

--- a/dms/migrations/13.0.4.0.0/pre-migration.py
+++ b/dms/migrations/13.0.4.0.0/pre-migration.py
@@ -1,0 +1,21 @@
+# Copyright 2021 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+def convert_root_storage_id_in_storage_id(env):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE dms_directory
+        SET storage_id = root_storage_id
+        WHERE root_storage_id IS NOT NULL
+        AND parent_id IS NULL
+        """,
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    convert_root_storage_id_in_storage_id(env)

--- a/dms/models/abstract_dms_mixin.py
+++ b/dms/models/abstract_dms_mixin.py
@@ -20,16 +20,24 @@ class AbstractDmsMixin(models.AbstractModel):
         comodel_name="dms.storage", string="Storage", store=True,
     )
     is_hidden = fields.Boolean(
-        string="Storage is Hidden", related="storage_id.is_hidden", readonly=True
+        string="Storage is Hidden",
+        related="storage_id.is_hidden",
+        related_sudo=True,
+        auto_join=True,
+        readonly=True,
+        store=True,
     )
     company_id = fields.Many2one(
         related="storage_id.company_id",
+        related_sudo=True,
+        auto_join=True,
         comodel_name="res.company",
         string="Company",
         readonly=True,
         store=True,
         index=True,
     )
+    storage_id_save_type = fields.Selection(related="storage_id.save_type", store=False)
     color = fields.Integer(string="Color", default=0)
     category_id = fields.Many2one(
         comodel_name="dms.category",

--- a/dms/models/category.py
+++ b/dms/models/category.py
@@ -30,7 +30,7 @@ class Category(models.Model):
         default=True,
         help="The active field allows you to hide the category without removing it.",
     )
-    complete_name = fields.Char(compute="_compute_complete_name", store=True,)
+    complete_name = fields.Char(compute="_compute_complete_name", store=True)
     parent_id = fields.Many2one(
         comodel_name="dms.category",
         string="Parent Category",

--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -1,5 +1,6 @@
 # Copyright 2020 Antoni Romera
 # Copyright 2017-2019 MuK IT GmbH
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import base64
@@ -58,6 +59,7 @@ class File(models.Model):
     # Override acording to defined in AbstractDmsMixin
     storage_id = fields.Many2one(
         related="directory_id.storage_id",
+        related_sudo=True,
         comodel_name="dms.storage",
         string="Storage",
         auto_join=True,
@@ -155,6 +157,12 @@ class File(models.Model):
                             return True
         return res
 
+    res_model = fields.Char(
+        string="Linked attachments model", related="directory_id.res_model"
+    )
+    res_id = fields.Integer(
+        string="Linked attachments record ID", related="directory_id.res_id"
+    )
     attachment_id = fields.Many2one(
         comodel_name="ir.attachment",
         string="Attachment File",
@@ -162,7 +170,6 @@ class File(models.Model):
         invisible=True,
         ondelete="cascade",
     )
-    storage_id_save_type = fields.Selection(related="storage_id.save_type", store=False)
 
     def get_human_size(self):
         return human_size(self.size)
@@ -653,7 +660,7 @@ class File(models.Model):
     def create(self, vals_list):
         new_vals_list = []
         for vals in vals_list:
-            if "res_model" not in vals and "res_id" not in vals:
+            if "attachment_id" not in vals:
                 vals = self._create_model_attachment(vals)
             new_vals_list.append(vals)
         return super(File, self).create(new_vals_list)

--- a/dms/models/ir_attachment.py
+++ b/dms/models/ir_attachment.py
@@ -50,8 +50,6 @@ class IrAttachment(models.Model):
                         "name": attachment.name,
                         "directory_id": directory.id,
                         "attachment_id": attachment.id,
-                        "res_model": attachment.res_model,
-                        "res_id": attachment.res_id,
                     }
                 )
 

--- a/dms/models/res_company.py
+++ b/dms/models/res_company.py
@@ -93,7 +93,7 @@ class ResCompany(models.Model):
             **self.env.context,
             **{
                 "default_is_root_directory": True,
-                "default_root_storage_id": storage and storage.id,
+                "default_storage_id": storage and storage.id,
             },
         }
         return action

--- a/dms/models/storage.py
+++ b/dms/models/storage.py
@@ -51,7 +51,7 @@ class Storage(models.Model):
 
     root_directory_ids = fields.One2many(
         comodel_name="dms.directory",
-        inverse_name="root_storage_id",
+        inverse_name="storage_id",
         string="Root Directories",
         auto_join=False,
         readonly=False,

--- a/dms/tests/common.py
+++ b/dms/tests/common.py
@@ -1,5 +1,6 @@
 # Copyright 2017-2019 MuK IT GmbH.
 # Copyright 2020 Creu Blanca
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 import base64
 import functools
@@ -200,13 +201,15 @@ class DocumentsBaseCase(common.TransactionCase):
                     "name": uuid.uuid4().hex,
                     "is_root_directory": False,
                     "parent_id": directory.id,
+                    "storage_id": directory.storage_id.id,
                 }
             )
         return model.create(
             {
                 "name": uuid.uuid4().hex,
                 "is_root_directory": True,
-                "root_storage_id": storage.id,
+                "storage_id": storage.id,
+                "parent_id": False,
             }
         )
 
@@ -215,20 +218,6 @@ class DocumentsBaseCase(common.TransactionCase):
         if not directory:
             directory = self.create_directory(storage=storage, sudo=sudo)
         return model.create(
-            {
-                "name": uuid.uuid4().hex,
-                "directory_id": directory.id,
-                "content": content or self.content_base64(),
-            }
-        )
-
-    def create_file_with_context(
-        self, context, directory=False, content=False, storage=False, sudo=False
-    ):
-        model = self.file.sudo() if sudo else self.file
-        if not directory:
-            directory = self.create_directory(storage=storage, sudo=sudo)
-        return model.with_context(context).create(
             {
                 "name": uuid.uuid4().hex,
                 "directory_id": directory.id,

--- a/dms/tests/data/dms.directory.csv
+++ b/dms/tests/data/dms.directory.csv
@@ -1,4 +1,4 @@
-id,name,parent_id/id,root_storage_id/id,is_root_directory,category_id/id,tag_ids/id
+id,name,parent_id/id,storage_id/id,is_root_directory,category_id/id,tag_ids/id
 dms.directory_001_benchmark,D_0001,,dms.storage_001_benchmark,TRUE,dms.category_041_benchmark,dms.tag_042_benchmark
 dms.directory_002_benchmark,D_0002,,dms.storage_002_benchmark,TRUE,dms.category_021_benchmark,dms.tag_140_benchmark
 dms.directory_003_benchmark,D_0003,,dms.storage_001_benchmark,TRUE,dms.category_017_benchmark,dms.tag_017_benchmark

--- a/dms/tests/test_file_database.py
+++ b/dms/tests/test_file_database.py
@@ -1,6 +1,9 @@
 # Copyright 2017-2019 MuK IT GmbH.
 # Copyright 2020 Creu Blanca
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo.exceptions import UserError
 
 from .common import DocumentsBaseCase, multi_users
 
@@ -67,19 +70,13 @@ class FileTestCase(DocumentsBaseCase):
 
     @multi_users(lambda self: self.multi_users(), callback="_setup_test_data")
     def test_move_directory(self):
-        file = self.directory_root_demo_03.file_ids[0]
-        path_names = file.path_names
-        self.directory_root_demo_01.write(
-            {
-                "root_storage_id": False,
-                "is_root_directory": False,
-                "parent_id": self.directory_root_demo_02.id,
-            }
-        )
-        self.directory_root_demo_01.flush()
-        # We need to refresh as the field is not stored
-        file.refresh()
-        self.assertNotEqual(path_names, file.path_names)
+        with self.assertRaises(UserError):
+            self.directory_root_demo_01.write(
+                {
+                    "is_root_directory": False,
+                    "parent_id": self.directory_root_demo_02.id,
+                }
+            )
 
     @multi_users(lambda self: self.multi_users(), callback="_setup_test_data")
     def test_unlink_file(self):

--- a/dms/tests/test_ir_attachment.py
+++ b/dms/tests/test_ir_attachment.py
@@ -38,8 +38,8 @@ class IrAttachmentTestCase(common.TransactionCase):
             "res_id": self.partner.id,
             "datas": self.content_base64(),
         }
-        attachment = self.attachment.sudo(self.user_demo).create(vals)
+        attachment = self.attachment.with_user(self.user_demo).create(vals)
         self.assertEquals(attachment.name, "Test file")
         vals["name"] = "Test file 2"
-        attachment = self.attachment.sudo(self.unprivileged_user).create(vals)
+        attachment = self.attachment.with_user(self.unprivileged_user).create(vals)
         self.assertEquals(attachment.name, "Test file 2")

--- a/dms/views/directory.xml
+++ b/dms/views/directory.xml
@@ -440,14 +440,8 @@
                             <field
                                 name="storage_id"
                                 options="{'no_open': True}"
-                                attrs="{'invisible':['|', ('is_root_directory','=',True), ('parent_id','=',False)]}"
-                            />
-                            <field
-                                name="root_storage_id"
-                                options="{'no_open': True}"
-                                readonly="1"
-                                invisible="context.get('hide_root_storage', False)"
-                                attrs="{'invisible':[('is_root_directory','=',False)], 'required':[('is_root_directory','=',True)]}"
+                                attrs="{'readonly':[('is_root_directory','=',False)], 'required':[('is_root_directory','=',True)]}"
+                                force_save="1"
                             />
                         </group>
                         <group>
@@ -625,10 +619,6 @@
             <field name="is_root_directory" position="attributes">
                 <attribute name="invisible">0</attribute>
             </field>
-            <field name="root_storage_id" position="attributes">
-                <attribute name="readonly">0</attribute>
-                <attribute name="options">{'no_quick_create': True}</attribute>
-            </field>
             <field name="storage_id" position="attributes">
                 <attribute name="options">{}</attribute>
             </field>
@@ -679,8 +669,10 @@
                     <group>
                         <field name="is_root_directory" readonly="1" />
                         <field
-                            name="root_storage_id"
+                            name="storage_id"
                             options="{'no_quick_create': True}"
+                            attrs="{'readonly':[('is_root_directory','=',False)], 'required':[('is_root_directory','=',True)]}"
+                            force_save="1"
                         />
                     </group>
                     <group>

--- a/dms/views/storage.xml
+++ b/dms/views/storage.xml
@@ -18,7 +18,7 @@
         </field>
         <field name="context">
             {
-            'default_root_storage_id': active_id,
+            'default_storage_id': active_id,
             'default_is_root_directory': True,
             }
         </field>
@@ -185,7 +185,7 @@
                             <field
                                 name="root_directory_ids"
                                 groups="dms.group_dms_manager"
-                                context="{'hide_root_storage': True,'default_root_storage_id': active_id, 'default_is_root_directory': True}"
+                                context="{'hide_root_storage': True,'default_storage_id': active_id, 'default_is_root_directory': True}"
                             >
                                 <tree string="Root Directories">
                                     <field name="name" />


### PR DESCRIPTION
Prevent `parent_id` error in directories in some UI cases

![dms-error](https://user-images.githubusercontent.com/4117568/112959367-a448c180-9143-11eb-85c4-580c0598b008.png)

Changes:
- [FIX] dms: Prevent `parent_id` error in directories in some UI cases
- [FIX] dms: Change `allowed_model_ids` field in directory to related
- [FIX] dms: Change `res_model` + `res_id` fields in files to related

Steps to reproduce:

- Create root directory according to some storage.
- Enter in directory created and go to "Subdirectories"
- Create new directory (error appear).

Please @pedrobaeza, @joao-p-marques and @etobella can you review it?

@Tecnativa TT29019