### PR TITLE
[13.0][FIX] dms: Add domain operator to drop target (files) in any kanban file view

### DIFF
--- a/dms/static/src/js/views/many_drop_target.js
+++ b/dms/static/src/js/views/many_drop_target.js
@@ -68,7 +68,10 @@ odoo.define("dms.DragDrop", function(require) {
         _onSearchPanelDomainUpdated: function(ev) {
             var directory_id = false;
             _.each(ev.data.domain, function(domain) {
-                if (domain[0] === "directory_id" && domain[1] === "child_of") {
+                if (
+                    domain[0] === "directory_id" &&
+                    (domain[1] === "child_of" || domain[1] === "=")
+                ) {
                     directory_id = domain[2];
                 }
             });


### PR DESCRIPTION
Fixes issue #69

FWP from 12.0: https://github.com/OCA/dms/pull/70

Domain on this line of (`_onSearchPanelDomainUpdated`) should include the `=` operator in order to select properly directory_id.

When it's merged i will add it to migration PR to 14.0

Please @pedrobaeza and @joao-p-marques can you review it?