### PR TITLE
[12.0] [FIX] dms: Check `default_directory_id` context key when creating attachment

### DIFF
--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -649,6 +649,10 @@ class File(models.Model):
             directory = directory_model.browse(res_vals["directory_id"])
         elif self.env.context.get("active_id"):
             directory = directory_model.browse(self.env.context.get("active_id"))
+        elif self.env.context.get("default_directory_id"):
+            directory = directory_model.browse(
+                self.env.context.get("default_directory_id")
+            )
         if (
             directory
             and directory.res_model


### PR DESCRIPTION
When creating an attachment, check `default_directory_id` too because this key comes from kanban js view and it's like `active_id` when creating files from drag and drop (drop target).

This change will allow to view the new file on the associated record if the folder has `res_model` and `res_id` (the parent folder is an attachment storage)

Fixes #72