### PR TITLE
[13.0] [FIX] dms: Check default_directory_id context key when creating attachment

### DIFF
--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -597,7 +597,12 @@ class File(models.Model):
 
     def _create_model_attachment(self, vals):
         res_vals = vals.copy()
-        directory_id = res_vals.get("directory_id", self.env.context.get("active_id"))
+        if "directory_id" in res_vals:
+            directory_id = res_vals["directory_id"]
+        elif self.env.context.get("active_id"):
+            directory_id = self.env.context.get("active_id")
+        elif self.env.context.get("default_directory_id"):
+            directory_id = self.env.context.get("default_directory_id")
         directory = self.env["dms.directory"].browse(directory_id)
         if directory.res_model and directory.res_id:
             attachment = (


### PR DESCRIPTION
FWP from 12.0: https://github.com/OCA/dms/pull/73

When creating an attachment, check default_directory_id too because this key comes from kanban js view and it's like active_id when creating files from drag and drop (drop target).

This change will allow to view the new file on the associated record if the folder has res_model and res_id (the parent folder is an attachment storage)

Please @pedrobaeza and @joao-p-marques can you review it?