### PR TITLE
[13.0][FIX] dms: Improve _get_share_url() function to add share_token parameter

### DIFF
--- a/dms/models/directory.py
+++ b/dms/models/directory.py
@@ -196,7 +196,9 @@ class DmsDirectory(models.Model):
             if record.res_id:
                 model.browse(record.res_id).check_access_rule(operation)
 
-    def _get_share_url(self, redirect=False, signup_partner=False, pid=None):
+    def _get_share_url(
+        self, redirect=False, signup_partner=False, pid=None, share_token=True
+    ):
         self.ensure_one()
         return "/my/dms/directory/{}?access_token={}&db={}".format(
             self.id, self._portal_ensure_token(), self.env.cr.dbname,

--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -178,7 +178,9 @@ class File(models.Model):
     def get_human_size(self):
         return human_size(self.size)
 
-    def _get_share_url(self, redirect=False, signup_partner=False, pid=None):
+    def _get_share_url(
+        self, redirect=False, signup_partner=False, pid=None, share_token=True
+    ):
         self.ensure_one()
         return "/my/dms/file/{}/download?access_token={}&db={}".format(
             self.id, self._portal_ensure_token(), self.env.cr.dbname,


### PR DESCRIPTION
Improve `_get_share_url()` function to add share_token parameter (according to https://github.com/odoo/odoo/commit/a55f125f5420797a9378925da5626e43d002b9b0).

It's need to apply in 14.0 too.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT29820