### PR TITLE
[14.0][FIX] dms: Remove `_get_share_url()` function because is not necessary to override nothing

### DIFF
--- a/dms/models/directory.py
+++ b/dms/models/directory.py
@@ -197,14 +197,6 @@ class DmsDirectory(models.Model):
             if record.res_id:
                 model.browse(record.res_id).check_access_rule(operation)
 
-    def _get_share_url(self, redirect=False, signup_partner=False, pid=None):
-        self.ensure_one()
-        return "/my/dms/directory/{}?access_token={}&db={}".format(
-            self.id,
-            self._portal_ensure_token(),
-            self.env.cr.dbname,
-        )
-
     def check_access_token(self, access_token=False):
         res = False
         if access_token:

--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -180,14 +180,6 @@ class File(models.Model):
     def get_human_size(self):
         return human_size(self.size)
 
-    def _get_share_url(self, redirect=False, signup_partner=False, pid=None):
-        self.ensure_one()
-        return "/my/dms/file/{}/download?access_token={}&db={}".format(
-            self.id,
-            self._portal_ensure_token(),
-            self.env.cr.dbname,
-        )
-
     # ----------------------------------------------------------
     # Helper
     # ----------------------------------------------------------


### PR DESCRIPTION
Remove `_get_share_url()` function because is not necessary to override nothing (default work fine according to share wizard and auto-add `access_token` in link).

It's need to apply in 13.0 too.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT29820