### PR TITLE
[13.0][FIX] dms: Improve tests (prevent error if installed other addons after dms install and new addons auto-create partners)

### DIFF
--- a/dms/tests/test_storage_attachment.py
+++ b/dms/tests/test_storage_attachment.py
@@ -21,7 +21,9 @@ class StorageAttachmentTestCase(DocumentsBaseCase):
 
     def test_storage_attachment(self):
         self._create_attachment("demo.txt", self.admin_uid)
-        self.assertEqual(self.storage.count_storage_files, 1)
+        self.assertTrue(
+            self.storage.storage_file_ids.filtered(lambda x: x.name == "demo.txt")
+        )
         directory_id = self.directory.with_user(self.admin_uid).search(
             [
                 ("storage_id", "=", self.storage.id),
@@ -37,7 +39,7 @@ class StorageAttachmentTestCase(DocumentsBaseCase):
         self.assertEqual(file_01.storage_id, self.storage)
         self.assertEqual(file_01.storage_id.save_type, "attachment")
         self.assertEqual(file_01.save_type, "database")
-        self.assertEqual(self.storage.count_storage_files, 2)
+        self.assertEqual(directory_id.count_files, 2)
 
     def test_storage_attachment_directory_record_ref_access(self):
         self._create_attachment("demo.txt", self.admin_uid)
@@ -51,7 +53,18 @@ class StorageAttachmentTestCase(DocumentsBaseCase):
         self.assertTrue(directory_id.with_user(self.admin_uid).check_access("read"))
         # demo can access res_partner_12
         self.browse_ref("base.user_demo").write(
-            {"groups_id": [(2, self.browse_ref("dms.group_dms_user").id, False)]}
+            {
+                "groups_id": [
+                    (
+                        6,
+                        0,
+                        [
+                            self.browse_ref("base.group_user").id,
+                            self.browse_ref("dms.group_dms_user").id,
+                        ],
+                    )
+                ]
+            }
         )
         self.assertEqual(self.partner.type, "contact")
         self.assertTrue(directory_id.with_user(self.demo_uid).check_access("read"))


### PR DESCRIPTION
Improve tests to prevent error if installed other addons after dms install and new addons auto-create partners..

Please @joao-p-marques and @pedrobaeza can you review it?

It's need to apply in 14.0

@Tecnativa TT30121

