### PR TITLE
[13.0][FIX] dms: Remove _get_share_url() function because is not necessary to override nothing

### DIFF
--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -183,14 +183,6 @@ class File(models.Model):
     def get_human_size(self):
         return human_size(self.size)
 
-    def _get_share_url(
-        self, redirect=False, signup_partner=False, pid=None, share_token=True
-    ):
-        self.ensure_one()
-        return "/my/dms/file/{}/download?access_token={}&db={}".format(
-            self.id, self._portal_ensure_token(), self.env.cr.dbname,
-        )
-
     # ----------------------------------------------------------
     # Helper
     # ----------------------------------------------------------


### PR DESCRIPTION
Remove `_get_share_url()` function because is not necessary to override nothing (default work fine according to share wizard and auto-add `access_token` in link).

It's related to https://github.com/OCA/dms/pull/79 (14.0).

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT29820