### PR TITLE
[FIX] dms: cascade removal of related files/directories

### DIFF
--- a/dms/models/__init__.py
+++ b/dms/models/__init__.py
@@ -1,4 +1,5 @@
 from . import access_groups
+from . import base
 from . import mixins_thumbnail
 from . import dms_security_mixin
 

--- a/dms/models/base.py
+++ b/dms/models/base.py
@@ -1,0 +1,19 @@
+# Copyright 2021 Tecnativa - Jairo Llopis
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import models
+
+
+class Base(models.AbstractModel):
+    _inherit = "base"
+
+    def unlink(self):
+        """Cascade DMS related resources removal."""
+        result = super().unlink()
+        self.env["dms.file"].sudo().search(
+            [("res_model", "=", self._name), ("res_id", "in", self.ids)]
+        ).unlink()
+        self.env["dms.directory"].sudo().search(
+            [("res_model", "=", self._name), ("res_id", "in", self.ids)]
+        ).unlink()
+        return result

--- a/dms/tests/test_storage_attachment.py
+++ b/dms/tests/test_storage_attachment.py
@@ -9,7 +9,7 @@ class StorageAttachmentTestCase(DocumentsBaseCase):
         super().setUp()
         self.storage = self.browse_ref("dms.storage_attachment_demo")
         self.model_res_partner = self.browse_ref("base.model_res_partner")
-        self.partner = self.browse_ref("base.res_partner_12")
+        self.partner = self.env["res.partner"].create({"name": "test partner"})
 
     def _create_attachment(self, name, uid):
         self.create_attachment(
@@ -40,6 +40,10 @@ class StorageAttachmentTestCase(DocumentsBaseCase):
         self.assertEqual(file_01.storage_id.save_type, "attachment")
         self.assertEqual(file_01.save_type, "database")
         self.assertEqual(self.storage.count_storage_files, 2)
+        # Assert cascade removal
+        self.partner.unlink()
+        self.assertFalse(file_01.exists())
+        self.assertFalse(directory_id.exists())
 
     def test_storage_attachment_directory_record_ref_access(self):
         self._create_attachment("demo.txt", self.admin_uid)


### PR DESCRIPTION
When some dms.directory or dms.file was related to a real DB record (a.k.a. attachment storage), if the record got deleted, the DMS mirror was still alive.

If the dms.storage had inherit_access_from_parent_record=True, the situation got worse because the dms.directory became visible to everyone.

@Tecnativa TT30223