### PR TITLE
[12.0][FIX] dms: me cases admin and demo users have previously in 'Show private access' group and causes some tests to fail.

### DIFF
--- a/dms/tests/test_storage_attachment.py
+++ b/dms/tests/test_storage_attachment.py
@@ -17,6 +17,11 @@ class StorageAttachmentTestCase(DocumentsBaseCase):
                 "groups_id": [(6, 0, [self.env.ref("base.group_user").id])],
             }
         )
+        user_admin = self.browse_ref("base.user_admin")
+        self.user_demo = self.browse_ref("base.user_demo")
+        (user_admin + self.user_demo).write(
+            {"groups_id": [(3, self.ref("base.group_private_addresses"))]}
+        )
 
     def _create_attachment(self, name, uid):
         self.create_attachment(
@@ -73,7 +78,7 @@ class StorageAttachmentTestCase(DocumentsBaseCase):
         self.assertFalse(directory_id.sudo(self.demo_uid).permission_read)
         self.assertFalse(directory_id.sudo(self.user.id).permission_read)
         # user can access self.partner
-        self.browse_ref("base.user_demo").write(
+        self.user_demo.write(
             {
                 "groups_id": [
                     (


### PR DESCRIPTION
In some cases admin and demo users have previously in 'Show private access' group and causes some tests to fail. (Standarize according to 13.0) (It's fixed directly in https://github.com/OCA/dms/pull/107)

Please @pedrobaeza and @Yajo can you review it?

@Tecnativa