### PR TITLE
[14.0][REF] dms: modify permissions computation

### DIFF
--- a/dms/controllers/portal.py
+++ b/dms/controllers/portal.py
@@ -11,13 +11,13 @@ from odoo.addons.web.controllers.main import content_disposition, ensure_db
 
 class CustomerPortal(CustomerPortal):
     def _dms_check_access(self, model, res_id, access_token=None):
+        item = request.env[model].browse(res_id)
         if access_token:
-            item = request.env[model].sudo().browse(res_id)
+            item = item.sudo()
             if not item.check_access_token(access_token):
                 return False
         else:
-            item = request.env[model].browse(res_id)
-            if not item.with_user(request.env.user.id).check_access("read", False):
+            if not item.permission_read:
                 return False
         return item
 
@@ -27,12 +27,7 @@ class CustomerPortal(CustomerPortal):
         values.update({"dms_directory_count": len(ids)})
         return values
 
-    @http.route(
-        ["/my/dms"],
-        type="http",
-        auth="user",
-        website=True,
-    )
+    @http.route(["/my/dms"], type="http", auth="user", website=True)
     def portal_my_dms(
         self, sortby=None, filterby=None, search=None, search_in="name", **kw
     ):
@@ -128,7 +123,6 @@ class CustomerPortal(CustomerPortal):
                 domain, order=sort_br
             )
         request.session["my_dms_folder_history"] = dms_directory_items.ids
-        # check_access
         res = self._dms_check_access("dms.directory", dms_directory_id, access_token)
         if not res:
             if access_token:

--- a/dms/demo/access_group.xml
+++ b/dms/demo/access_group.xml
@@ -2,7 +2,6 @@
 <odoo noupdate="1">
     <record id="access_group_01_demo" model="dms.access.group">
         <field name="name">Admin</field>
-        <field name="perm_read">True</field>
         <field name="perm_create">True</field>
         <field name="perm_write">True</field>
         <field name="perm_unlink">True</field>
@@ -13,12 +12,10 @@
     </record>
     <record id="access_group_02_demo" model="dms.access.group">
         <field name="name">Portal</field>
-        <field name="perm_read">True</field>
         <field name="group_ids" eval="[(6, 0, [ref('base.group_portal')])]" />
     </record>
     <record id="access_group_03_demo" model="dms.access.group">
         <field name="name">Only admin user</field>
-        <field name="perm_read">True</field>
         <field name="perm_create">True</field>
         <field name="perm_write">True</field>
         <field name="perm_unlink">True</field>

--- a/dms/demo/directory.xml
+++ b/dms/demo/directory.xml
@@ -29,6 +29,7 @@
             name="tag_ids"
             eval="[(6, 0, [ref('dms.tag_01_demo'), ref('dms.tag_03_demo')])]"
         />
+        <field name="group_ids" eval="[(6, 0, [ref('dms.access_group_01_demo')])]" />
     </record>
     <record id="directory_03_demo" model="dms.directory">
         <field name="name">Sheets</field>
@@ -105,6 +106,10 @@
         <field
             name="tag_ids"
             eval="[(6, 0, [ref('dms.tag_04_demo'), ref('dms.tag_05_demo')])]"
+        />
+        <field
+            name="group_ids"
+            eval="[(6, 0, [ref('dms.access_group_01_demo'), ref('dms.access_group_02_demo')])]"
         />
     </record>
     <record id="directory_12_demo" model="dms.directory">

--- a/dms/models/abstract_dms_mixin.py
+++ b/dms/models/abstract_dms_mixin.py
@@ -1,6 +1,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class AbstractDmsMixin(models.AbstractModel):
@@ -8,30 +8,18 @@ class AbstractDmsMixin(models.AbstractModel):
     _description = "Abstract Dms Mixin"
 
     name = fields.Char(string="Name", required=True, index=True)
-    res_model = fields.Char(string="Linked attachments model")
-    res_id = fields.Integer(string="Linked attachments record ID")
-    record_ref = fields.Reference(
-        string="Record Referenced",
-        compute="_compute_record_ref",
-        selection=lambda self: self._get_ref_selection(),
-    )
     # Only defined to prevent error in other fields that related it
     storage_id = fields.Many2one(
-        comodel_name="dms.storage",
-        string="Storage",
-        store=True,
+        comodel_name="dms.storage", string="Storage", store=True, copy=True
     )
     is_hidden = fields.Boolean(
         string="Storage is Hidden",
         related="storage_id.is_hidden",
-        related_sudo=True,
         readonly=True,
         store=True,
     )
     company_id = fields.Many2one(
         related="storage_id.company_id",
-        related_sudo=True,
-        auto_join=True,
         comodel_name="res.company",
         string="Company",
         readonly=True,
@@ -45,15 +33,3 @@ class AbstractDmsMixin(models.AbstractModel):
         context="{'dms_category_show_path': True}",
         string="Category",
     )
-
-    @api.model
-    def _get_ref_selection(self):
-        models = self.env["ir.model"].search([])
-        return [(model.model, model.name) for model in models]
-
-    @api.depends("res_model", "res_id")
-    def _compute_record_ref(self):
-        for record in self:
-            record.record_ref = False
-            if record.res_model and record.res_id:
-                record.record_ref = "{},{}".format(record.res_model, record.res_id)

--- a/dms/models/access_groups.py
+++ b/dms/models/access_groups.py
@@ -2,28 +2,57 @@
 # Copyright 2020 RGB Consulting
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class DmsAccessGroups(models.Model):
     _name = "dms.access.group"
     _description = "Record Access Groups"
-
     _parent_store = True
     _parent_name = "parent_group_id"
 
     name = fields.Char(string="Group Name", required=True, translate=True)
     parent_path = fields.Char(string="Parent Path", index=True)
-    perm_read = fields.Boolean(string="Read Access")
+
+    # Permissions written directly on this group
     perm_create = fields.Boolean(string="Create Access")
     perm_write = fields.Boolean(string="Write Access")
     perm_unlink = fields.Boolean(string="Unlink Access")
+
+    # Permissions computed including parent group
+    perm_inclusive_create = fields.Boolean(
+        string="Inherited Create Access",
+        compute="_compute_inclusive_permissions",
+        store=True,
+    )
+    perm_inclusive_write = fields.Boolean(
+        string="Inherited Write Access",
+        compute="_compute_inclusive_permissions",
+        store=True,
+    )
+    perm_inclusive_unlink = fields.Boolean(
+        string="Inherited Unlink Access",
+        compute="_compute_inclusive_permissions",
+        store=True,
+    )
+
     directory_ids = fields.Many2many(
         comodel_name="dms.directory",
         relation="dms_directory_groups_rel",
         string="Directories",
         column1="gid",
         column2="aid",
+        auto_join=True,
+        readonly=True,
+    )
+    complete_directory_ids = fields.Many2many(
+        comodel_name="dms.directory",
+        relation="dms_directory_complete_groups_rel",
+        column1="gid",
+        column2="aid",
+        string="Complete directories",
+        auto_join=True,
         readonly=True,
     )
     count_users = fields.Integer(compute="_compute_users", string="Users", store=True)
@@ -34,7 +63,6 @@ class DmsAccessGroups(models.Model):
         comodel_name="dms.access.group",
         string="Parent Group",
         ondelete="cascade",
-        auto_join=True,
         index=True,
     )
 
@@ -64,6 +92,7 @@ class DmsAccessGroups(models.Model):
         column2="uid",
         string="Group Users",
         compute="_compute_users",
+        auto_join=True,
         store=True,
     )
 
@@ -75,6 +104,29 @@ class DmsAccessGroups(models.Model):
     _sql_constraints = [
         ("name_uniq", "unique (name)", "The name of the group must be unique!")
     ]
+
+    @api.depends(
+        "parent_group_id.perm_inclusive_create",
+        "parent_group_id.perm_inclusive_unlink",
+        "parent_group_id.perm_inclusive_write",
+        "parent_path",
+        "perm_create",
+        "perm_unlink",
+        "perm_write",
+    )
+    def _compute_inclusive_permissions(self):
+        """Provide full permissions inheriting from parent recursively."""
+        for one in self:
+            one.update(
+                {
+                    "perm_inclusive_%s"
+                    % perm: (
+                        one["perm_%s" % perm]
+                        or one.parent_group_id["perm_inclusive_%s" % perm]
+                    )
+                    for perm in ("create", "unlink", "write")
+                }
+            )
 
     @api.model
     def default_get(self, fields_list):
@@ -98,3 +150,18 @@ class DmsAccessGroups(models.Model):
             users |= record.mapped("explicit_user_ids")
             users |= record.mapped("parent_group_id.users")
             record.update({"users": users, "count_users": len(users)})
+
+    @api.constrains("parent_path")
+    def _check_parent_recursiveness(self):
+        """Forbid recursive relationships."""
+        for one in self:
+            if not one.parent_group_id:
+                continue
+            if str(one.id) in one.parent_path.split("/"):
+                raise ValidationError(
+                    _("Parent group '%(parent)s' is child of '%(current)s'.")
+                    % {
+                        "parent": one.parent_group_id.display_name,
+                        "current": one.display_name,
+                    }
+                )

--- a/dms/models/directory.py
+++ b/dms/models/directory.py
@@ -5,13 +5,13 @@
 
 import ast
 import base64
-import functools
 import logging
-import operator
 from collections import defaultdict
 
 from odoo import _, api, fields, models, tools
-from odoo.exceptions import AccessError, UserError, ValidationError
+from odoo.exceptions import UserError, ValidationError
+from odoo.osv.expression import OR
+from odoo.tools import consteq
 
 from odoo.addons.http_routing.models.ir_http import slugify
 
@@ -40,6 +40,7 @@ class DmsDirectory(models.Model):
 
     _parent_store = True
     _parent_name = "parent_id"
+    _directory_field = _parent_name
 
     parent_path = fields.Char(index=True)
     is_root_directory = fields.Boolean(
@@ -60,16 +61,15 @@ class DmsDirectory(models.Model):
         ondelete="restrict",
         auto_join=True,
         store=True,
-        copy=True,
-        default=False,
     )
-
     parent_id = fields.Many2one(
         comodel_name="dms.directory",
-        domain="[('permission_create', '=', True)]",
         string="Parent Directory",
+        domain="[('permission_create', '=', True)]",
         ondelete="restrict",
-        auto_join=True,
+        # Access to a directory doesn't necessarily mean access its parent, so
+        # prefetching this field could lead to misleading access errors
+        prefetch=False,
         index=True,
         store=True,
         readonly=False,
@@ -85,6 +85,24 @@ class DmsDirectory(models.Model):
         else:
             return False
 
+    group_ids = fields.Many2many(
+        comodel_name="dms.access.group",
+        relation="dms_directory_groups_rel",
+        column1="aid",
+        column2="gid",
+        string="Groups",
+    )
+    complete_group_ids = fields.Many2many(
+        comodel_name="dms.access.group",
+        relation="dms_directory_complete_groups_rel",
+        column1="aid",
+        column2="gid",
+        string="Complete Groups",
+        compute="_compute_groups",
+        readonly=True,
+        store=True,
+        compute_sudo=True,
+    )
     complete_name = fields.Char(
         "Complete Name", compute="_compute_complete_name", store=True
     )
@@ -185,26 +203,28 @@ class DmsDirectory(models.Model):
                 """,
     )
 
-    def check_access_rule(self, operation):
-        super().check_access_rule(operation)
-        for record in self:
-            if not record.storage_id_inherit_access_from_parent_record:
-                record.check_access_groups(operation)
-                continue
-            # Check access to inherited model (and record)
-            try:
-                model = self.env[record.res_model]
-            except KeyError:
-                _logger.info(
-                    "Skipping access rule check for missing model (%s). "
-                    "This is normal if you are upgrading the database. "
-                    "Otherwise, you probably have garbage DMS data.",
-                    record.res_model,
-                )
-                continue
-            model.check_access_rights(operation)
-            if record.res_id:
-                model.browse(record.res_id).check_access_rule(operation)
+    @api.model
+    def _get_domain_by_access_groups(self, operation):
+        """Special rules for directories."""
+        self_filter = [
+            ("storage_id_inherit_access_from_parent_record", "=", False),
+            ("id", "inselect", self._get_access_groups_query(operation)),
+        ]
+        # Upstream only filters by parent directory
+        result = super()._get_domain_by_access_groups(operation)
+        if operation == "create":
+            # When creating, I need create access in parent directory, or
+            # self-create permission if it's a root directory
+            result = OR(
+                [
+                    [("is_root_directory", "=", False)] + result,
+                    [("is_root_directory", "=", True)] + self_filter,
+                ]
+            )
+        else:
+            # In other operations, I only need self access
+            result = self_filter
+        return result
 
     def _compute_access_url(self):
         super()._compute_access_url()
@@ -237,41 +257,24 @@ class DmsDirectory(models.Model):
     @api.model
     def _get_parent_categories(self, access_token):
         self.ensure_one()
-        directories = [self]
+        directories = []
         current_directory = self
+        while current_directory:
+            directories.insert(0, current_directory)
+            if access_token and consteq(current_directory.access_token, access_token):
+                return directories
+            current_directory = current_directory.parent_id
         if access_token:
-            # Only show parent categories to access_token
-            stop = False
-            while current_directory.parent_id and not stop:
-                if current_directory.access_token == access_token:
-                    stop = False
-                else:
-                    directories.append(current_directory.parent_id)
-                current_directory = current_directory.parent_id
-        else:
-            while (
-                current_directory.parent_id
-                and current_directory.parent_id.check_access("read", False)
-            ):
-                directories.append(current_directory.parent_id)
-                current_directory = current_directory.parent_id
-        return directories[::-1]
+            # Reaching here means we didn't find the directory accessible by this token
+            return [self]
+        return directories
 
     def _get_own_root_directories(self):
-        ids = []
-        items = self.env["dms.directory"].search([("is_hidden", "=", False)])
-        for item in items:
-            current_directory = item
-            while (
-                current_directory.parent_id
-                and current_directory.parent_id.check_access("read", False)
-            ):
-                current_directory = current_directory.parent_id
-
-            if current_directory.id not in ids:
-                ids.append(current_directory.id)
-
-        return ids
+        return (
+            self.env["dms.directory"]
+            .search([("is_hidden", "=", False), ("parent_id", "=", False)])
+            .ids
+        )
 
     allowed_model_ids = fields.Many2many(
         related="storage_id.model_ids",
@@ -284,6 +287,13 @@ class DmsDirectory(models.Model):
         inverse="_inverse_model_id",
         string="Model",
         store=True,
+    )
+    storage_id_save_type = fields.Selection(
+        related="storage_id.save_type",
+        related_sudo=True,
+        readonly=True,
+        store=False,
+        prefetch=False,
     )
     storage_id_inherit_access_from_parent_record = fields.Boolean(
         related="storage_id.inherit_access_from_parent_record",
@@ -383,22 +393,14 @@ class DmsDirectory(models.Model):
     @api.depends("child_directory_ids")
     def _compute_count_directories(self):
         for record in self:
-            directories = len(
-                record.child_directory_ids.filtered(lambda x: x.check_access("read"))
-            )
+            directories = len(record.child_directory_ids)
             record.count_directories = directories
             record.count_directories_title = _("%s Subdirectories") % directories
 
     @api.depends("file_ids")
     def _compute_count_files(self):
         for record in self:
-            files = len(
-                record.file_ids.filtered(lambda x: x.check_access("read"))
-            ) + len(
-                record.child_directory_ids.file_ids.filtered(
-                    lambda x: x.check_access("read")
-                )
-            )
+            files = len(record.file_ids)
             record.count_files = files
             record.count_files_title = _("%s Files") % files
 
@@ -441,29 +443,19 @@ class DmsDirectory(models.Model):
             )
             record.size = sum(rec.get("size", 0) for rec in recs)
 
-    @api.depends("inherit_group_ids", "parent_path")
+    @api.depends(
+        "group_ids",
+        "inherit_group_ids",
+        "parent_id.complete_group_ids",
+        "parent_path",
+    )
     def _compute_groups(self):
-        records = self.filtered(lambda record: record.parent_path)
-        paths = [list(map(int, rec.parent_path.split("/")[:-1])) for rec in records]
-        ids = paths and set(functools.reduce(operator.concat, paths)) or []
-        read = self.browse(ids).read(["inherit_group_ids", "group_ids"])
-        data = {entry.pop("id"): entry for entry in read}
-        for record in records:
-            complete_group_ids = set()
-            for directory_id in reversed(
-                list(map(int, record.parent_path.split("/")[:-1]))
-            ):
-                if directory_id in data:
-                    complete_group_ids |= set(data[directory_id].get("group_ids", []))
-                    if not data[directory_id].get("inherit_group_ids"):
-                        break
-            record.update({"complete_group_ids": [(6, 0, list(complete_group_ids))]})
-        for record in self - records:
-            if record.parent_id and record.inherit_group_ids:
-                complete_groups = record.parent_id.complete_group_ids
-                record.complete_group_ids = record.group_ids | complete_groups
-            else:
-                record.complete_group_ids = record.group_ids
+        """Get all DMS security groups affecting this directory."""
+        for one in self:
+            groups = one.group_ids
+            if one.inherit_group_ids:
+                groups |= one.parent_id.complete_group_ids
+            self.complete_group_ids = groups
 
     # ----------------------------------------------------------
     # View
@@ -512,9 +504,15 @@ class DmsDirectory(models.Model):
     @api.constrains("storage_id", "model_id")
     def _check_storage_id_attachment_model_id(self):
         for record in self:
-            if record.storage_id.save_type == "attachment" and not record.model_id:
+            if record.storage_id.save_type != "attachment":
+                continue
+            if not record.model_id:
                 raise ValidationError(
                     _("A directory has to have model in attachment storage.")
+                )
+            if not record.is_root_directory and not record.res_id:
+                raise ValidationError(
+                    _("This directory needs to be associated to a record.")
                 )
 
     @api.constrains("is_root_directory", "storage_id")
@@ -532,17 +530,6 @@ class DmsDirectory(models.Model):
                 )
             if not record.is_root_directory and not record.parent_id:
                 raise ValidationError(_("A directory has to have a parent directory."))
-
-    @api.constrains("parent_id")
-    def _check_directory_access(self):
-        for record in self:
-            if not record.parent_id.check_access("create", raise_exception=False):
-                raise ValidationError(
-                    _(
-                        "The parent directory has to have the permission "
-                        "to create directories."
-                    )
-                )
 
     @api.constrains("name")
     def _check_name(self):
@@ -651,7 +638,11 @@ class DmsDirectory(models.Model):
                 parent = self.browse([vals["parent_id"]])
                 data = next(iter(parent.sudo().read(["storage_id"])), {})
                 vals["storage_id"] = self._convert_to_write(data).get("storage_id")
-        return super().create(vals_list)
+        # Hack to prevent error related to mail_message parent not exists in some cases
+        ctx = dict(self.env.context).copy()
+        ctx.update({"default_parent_id": False})
+        res = super(DmsDirectory, self.with_context(ctx)).create(vals_list)
+        return res
 
     def write(self, vals):
         if vals.get("storage_id"):
@@ -678,20 +669,12 @@ class DmsDirectory(models.Model):
         return res
 
     def unlink(self):
-        if self and self.check_access("unlink", raise_exception=True):
-            domain = [
-                "&",
-                ("directory_id", "child_of", self.ids),
-                "&",
-                ("locked_by", "!=", self.env.uid),
-                ("locked_by", "!=", False),
-            ]
-            if self.env["dms.file"].sudo().search(domain):
-                raise AccessError(_("A file is locked, the folder cannot be deleted."))
-            self.env["dms.file"].sudo().search(
-                [("directory_id", "child_of", self.ids)]
-            ).unlink()
-            return super(
-                DmsDirectory, self.sudo().search([("id", "child_of", self.ids)])
-            ).unlink()
+        """Custom cascade unlink.
+
+        Cannot rely on DB backend's cascade because subfolder and subfile unlinks
+        must check custom permissions implementation.
+        """
+        self.file_ids.unlink()
+        if self.child_directory_ids:
+            self.child_directory_ids.unlink()
         return super().unlink()

--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -85,6 +85,7 @@ class File(models.Model):
         relation="dms_file_tag_rel",
         column1="fid",
         column2="tid",
+        domain="['|', ('category_id', '=', False),('category_id', '=?', category_id)]",
         string="Tags",
     )
 
@@ -424,24 +425,9 @@ class File(models.Model):
 
     @api.onchange("category_id")
     def _change_category(self):
-        res = {"domain": {"tag_ids": [("category_id", "=", False)]}}
-        if self.category_id:
-            res.update(
-                {
-                    "domain": {
-                        "tag_ids": [
-                            "|",
-                            ("category_id", "=", False),
-                            ("category_id", "child_of", self.category_id.id),
-                        ]
-                    }
-                }
-            )
-        tags = self.tag_ids.filtered(
+        self.tag_ids = self.tag_ids.filtered(
             lambda rec: not rec.category_id or rec.category_id == self.category_id
         )
-        self.tag_ids = tags
-        return res
 
     # ----------------------------------------------------------
     # Constrains

--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -65,11 +65,19 @@ class File(models.Model):
     )
 
     path_names = fields.Char(
-        compute="_compute_path", string="Path Names", readonly=True, store=False
+        compute="_compute_path",
+        compute_sudo=True,
+        string="Path Names",
+        readonly=True,
+        store=False,
     )
 
     path_json = fields.Text(
-        compute="_compute_path", string="Path Json", readonly=True, store=False
+        compute="_compute_path",
+        compute_sudo=True,
+        string="Path Json",
+        readonly=True,
+        store=False,
     )
 
     tag_ids = fields.Many2many(

--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -9,10 +9,10 @@ import json
 import logging
 from collections import defaultdict
 
-from odoo import SUPERUSER_ID, _, api, fields, models, tools
-from odoo.exceptions import AccessError, ValidationError
+from odoo import _, api, fields, models, tools
+from odoo.exceptions import ValidationError
 from odoo.osv import expression
-from odoo.tools import human_size
+from odoo.tools import consteq, human_size
 from odoo.tools.mimetypes import guess_mimetype
 
 from ..tools import file
@@ -59,12 +59,9 @@ class File(models.Model):
     # Override acording to defined in AbstractDmsMixin
     storage_id = fields.Many2one(
         related="directory_id.storage_id",
-        related_sudo=True,
-        comodel_name="dms.storage",
-        string="Storage",
-        auto_join=True,
         readonly=True,
         store=True,
+        prefetch=False,
     )
 
     path_names = fields.Char(
@@ -124,9 +121,7 @@ class File(models.Model):
         compute_sudo=True,
     )
     require_migration = fields.Boolean(
-        compute="_compute_migration",
-        store=True,
-        compute_sudo=True,
+        compute="_compute_migration", store=True, compute_sudo=True
     )
 
     content_file = fields.Binary(
@@ -145,7 +140,7 @@ class File(models.Model):
     def check_access_token(self, access_token=False):
         res = False
         if access_token:
-            if self.access_token and self.access_token == access_token:
+            if self.access_token and consteq(self.access_token, access_token):
                 return True
             else:
                 items = (
@@ -334,37 +329,27 @@ class File(models.Model):
     @api.depends("name", "directory_id", "directory_id.parent_path")
     def _compute_path(self):
         model = self.env["dms.directory"]
-        data = {}
         for record in self:
-            path_names = []
-            path_json = []
-            if record.directory_id.parent_path:
-                for directory_id in reversed(
-                    list(map(int, record.directory_id.parent_path.split("/")[:-1]))
-                ):
-                    if not directory_id:
-                        break
-                    if directory_id not in data:
-                        data[directory_id] = model.browse(directory_id)
-                    path_names.append(data[directory_id].name)
-                    path_json.append(
-                        {
-                            "model": model._name,
-                            "name": data[directory_id].name,
-                            "id": directory_id,
-                        }
-                    )
-            path_names.reverse()
-            path_json.reverse()
-            name = record.name_get()
-            path_names.append(name[0][1])
-            path_json.append(
+            path_names = [record.display_name]
+            path_json = [
                 {
                     "model": record._name,
-                    "name": name[0][1],
+                    "name": record.display_name,
                     "id": isinstance(record.id, int) and record.id or 0,
                 }
-            )
+            ]
+            current_dir = record.directory_id
+            while current_dir:
+                path_names.insert(0, current_dir.name)
+                path_json.insert(
+                    0,
+                    {
+                        "model": model._name,
+                        "name": current_dir.name,
+                        "id": current_dir.id,
+                    },
+                )
+                current_dir = current_dir.parent_id
             record.update(
                 {
                     "path_names": "/".join(path_names),
@@ -425,10 +410,6 @@ class File(models.Model):
                 record.migration = "{} > {}".format(file_label, storage_label)
                 record.require_migration = True
 
-    def read(self, fields=None, load="_classic_read"):
-        self.check_directory_access("read", {}, True)
-        return super(File, self).read(fields, load=load)
-
     # ----------------------------------------------------------
     # View
     # ----------------------------------------------------------
@@ -455,85 +436,10 @@ class File(models.Model):
         return res
 
     # ----------------------------------------------------------
-    # Security
-    # ----------------------------------------------------------
-
-    @api.model
-    def _get_directories_from_database(self, file_ids):
-        if not file_ids:
-            return self.env["dms.directory"]
-        return self.env["dms.file"].browse(file_ids).mapped("directory_id")
-
-    @api.model
-    def _read_group_process_groupby(self, gb, query):
-        if self.env.user.id == SUPERUSER_ID:
-            return super(File, self)._read_group_process_groupby(gb, query)
-        directories = (
-            self.env["dms.directory"].with_context(prefetch_fields=False).search([])
-        )
-        if directories:
-            where_clause = '"{table}"."{field}" = ANY (VALUES {ids})'.format(
-                table=self._table,
-                field="directory_id",
-                ids=", ".join(map(lambda id: "(%s)" % id, directories.ids)),
-            )
-        else:
-            where_clause = "0=1"
-        query.add_where(where_clause)
-        return super(File, self)._read_group_process_groupby(gb, query)
-
-    @api.model
-    def _search(
-        self,
-        args,
-        offset=0,
-        limit=None,
-        order=None,
-        count=False,
-        access_rights_uid=None,
-    ):
-        result = super(File, self)._search(
-            args, offset, limit, order, False, access_rights_uid
-        )
-        if self.env.user.id == SUPERUSER_ID:
-            return len(result) if count else result
-        # Fix access files with share button (public)
-        if self.env.user.has_group("base.group_public"):
-            return len(result) if count else result
-        # operations
-        if not result:
-            return 0 if count else []
-        file_ids = set(result)
-        directories = self._get_directories_from_database(result)
-        for directory in directories - directories._filter_access("read"):
-            file_ids -= set(directory.sudo().mapped("file_ids").ids)
-        return len(file_ids) if count else list(file_ids)
-
-    def _filter_access(self, operation):
-        records = super(File, self)._filter_access(operation)
-        if self.env.user.id == SUPERUSER_ID:
-            return records
-        directories = self._get_directories_from_database(records.ids)
-        for directory in directories - directories._filter_access("read"):
-            records -= self.browse(directory.sudo().mapped("file_ids").ids)
-        return records
-
-    def check_directory_access(self, operation, vals=False, raise_exception=False):
-        if not vals:
-            vals = {}
-        if self.env.user.id == SUPERUSER_ID:
-            return True
-        if "directory_id" in vals and vals["directory_id"]:
-            records = self.env["dms.directory"].browse(vals["directory_id"])
-        else:
-            records = self._get_directories_from_database(self.ids)
-        return records.check_access(operation, raise_exception)
-
-    # ----------------------------------------------------------
     # Constrains
     # ----------------------------------------------------------
 
-    @api.constrains("storage_id")
+    @api.constrains("storage_id", "res_model", "res_id")
     def _check_storage_id_attachment_res_model(self):
         for record in self:
             if record.storage_id.save_type == "attachment" and not (
@@ -572,14 +478,6 @@ class File(models.Model):
                 raise ValidationError(
                     _("The maximum upload size is %s MB).")
                     % self._get_binary_max_size()
-                )
-
-    @api.constrains("directory_id")
-    def _check_directory_access(self):
-        for record in self:
-            if not record.directory_id.check_access("create", raise_exception=False):
-                raise ValidationError(
-                    _("The directory has to have the permission to create files.")
                 )
 
     # ----------------------------------------------------------
@@ -635,21 +533,7 @@ class File(models.Model):
         else:
             names = self.sudo().directory_id.file_ids.mapped("name")
         default.update({"name": file.unique_name(self.name, names, self.extension)})
-        self.check_directory_access("create", default, True)
         return super(File, self).copy(default)
-
-    def write(self, vals):
-        self.check_directory_access("write", vals, True)
-        self.check_lock()
-        return super(File, self).write(vals)
-
-    def unlink(self):
-        self.check_access_rights("unlink")
-        self.check_directory_access("unlink", {}, True)
-        self.check_lock()
-        # We need to do sudo because we don't know when the related groups
-        # will be deleted
-        return super(File, self.sudo()).unlink()
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -679,18 +563,6 @@ class File(models.Model):
 
     def unlock(self):
         self.write({"locked_by": None})
-
-    @api.model
-    def _check_lock_editor(self, lock_uid):
-        return lock_uid in (self.env.uid, SUPERUSER_ID)
-
-    def check_lock(self):
-        for record in self:
-            if record.locked_by.exists() and not self._check_lock_editor(
-                record.locked_by.id
-            ):
-                message = _("The record (%s [%s]) is locked, by an other user.")
-                raise AccessError(message % (record._description, record.id))
 
     # ----------------------------------------------------------
     # Read, View

--- a/dms/models/dms_security_mixin.py
+++ b/dms/models/dms_security_mixin.py
@@ -2,339 +2,224 @@
 # Copyright 2021 Tecnativa - Víctor Martínez
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from collections import defaultdict
 
-from psycopg2 import sql
+from logging import getLogger
 
-from odoo import SUPERUSER_ID, _, api, fields, models
-from odoo.exceptions import AccessError
+from odoo import api, fields, models
+from odoo.osv.expression import FALSE_DOMAIN, NEGATIVE_TERM_OPERATORS, OR, TRUE_DOMAIN
+
+_logger = getLogger(__name__)
 
 
 class DmsSecurityMixin(models.AbstractModel):
     _name = "dms.security.mixin"
     _description = "DMS Security Mixin"
 
-    # If set the group fields are restricted by the access group
-    _access_groups_fields = False
+    # Submodels must define this field that points to the owner dms.directory
+    _directory_field = "directory_id"
 
-    # If set the group fields are recomputed as super administrator
-    _access_groups_sudo = True
-
-    # Set it to True to enforced security even if no group has been set
-    _access_groups_strict = False
-
+    res_model = fields.Char(string="Linked attachments model", index=True, store=True)
+    res_id = fields.Integer(
+        string="Linked attachments record ID", index=True, store=True
+    )
+    record_ref = fields.Reference(
+        string="Record Referenced",
+        compute="_compute_record_ref",
+        selection=lambda self: self._get_ref_selection(),
+    )
     permission_read = fields.Boolean(
-        compute="_compute_permissions_read",
+        compute="_compute_permissions",
         search="_search_permission_read",
         string="Read Access",
     )
-
     permission_create = fields.Boolean(
-        compute="_compute_permissions_create",
+        compute="_compute_permissions",
         search="_search_permission_create",
         string="Create Access",
     )
-
     permission_write = fields.Boolean(
-        compute="_compute_permissions_write",
+        compute="_compute_permissions",
         search="_search_permission_write",
         string="Write Access",
     )
-
     permission_unlink = fields.Boolean(
-        compute="_compute_permissions_unlink",
+        compute="_compute_permissions",
         search="_search_permission_unlink",
         string="Delete Access",
     )
 
     @api.model
-    def _add_magic_fields(self):
-        super(DmsSecurityMixin, self)._add_magic_fields()
+    def _get_ref_selection(self):
+        models = self.env["ir.model"].search([])
+        return [(model.model, model.name) for model in models]
 
-        def add(name, field):
-            if name not in self._fields:
-                self._add_field(name, field)
-
-        add(
-            "group_ids",
-            fields.Many2many(
-                _module=self._module,
-                comodel_name="dms.access.group",
-                relation="%s_groups_rel" % (self._table),
-                column1="aid",
-                column2="gid",
-                string="Groups",
-                automatic=True,
-                groups=self._access_groups_fields,
-            ),
-        )
-        add(
-            "complete_group_ids",
-            fields.Many2many(
-                _module=self._module,
-                comodel_name="dms.access.group",
-                relation="%s_complete_groups_rel" % (self._table),
-                column1="aid",
-                column2="gid",
-                string="Complete Groups",
-                compute="_compute_groups",
-                readonly=True,
-                store=True,
-                automatic=True,
-                compute_sudo=self._access_groups_sudo,
-                groups=self._access_groups_fields,
-            ),
-        )
-
-    def _filter_access(self, operation):
-        rec = self
-        if self.check_access_rights(operation, False):
-            rec = self._filter_access_rules(operation)
-        return rec.filter_access_groups(operation)
-
-    def _filter_access_ids(self, operation):
-        return self._filter_access(operation).ids
-
-    @api.model
-    def _apply_access_groups(self, query, mode="read"):
-        if self.env.user.id == SUPERUSER_ID:
-            return None
-        # Fix access directory and files with share button (public)
-        if self.env.user.has_group("base.group_public"):
-            return None
-
-        field = "id"
-        if self._name == "dms.file":
-            field = "directory_id"
-        where_clause = """
-            "{table}".{field} IN (
-                SELECT r.aid
-                FROM dms_directory_complete_groups_rel r
-                JOIN dms_access_group g ON r.gid = g.id
-                JOIN dms_access_group_users_rel u ON r.gid = u.gid
-                WHERE u.uid = %s AND (
-                    (%s = 'read' AND g.perm_read) OR
-                    (%s = 'create' AND g.perm_create) OR
-                    (%s = 'write' AND g.perm_write) OR
-                    (%s = 'unlink' AND g.perm_unlink)
-                )
-            )
-        """.format(
-            table=self._table, field=field
-        )
-        if not self._access_groups_strict:
-            exists_clause = """
-                NOT EXISTS (
-                    SELECT 1
-                        FROM dms_directory_complete_groups_rel r
-                        JOIN dms_access_group g ON r.gid = g.id
-                        WHERE r.aid = "{table}".{field}
-                )
-            """
-            exists_clause = exists_clause.format(table=self._table, field=field)
-            where_clause = "({groups_clause} OR {exists_clause})".format(
-                groups_clause=where_clause,
-                exists_clause=exists_clause,
-            )
-        query.add_where(where_clause, where_params=[self.env.user.id] + ([mode] * 4))
-        # Add _get_directory_ids_with_res_model_without_access
-        if self.env.context.get("use_res_model_without_access", True):
-            custom_ids = self._get_directory_ids_with_res_model_without_access(mode)
-            if custom_ids:
-                extra_clause = """
-                    "{table}".{field} NOT IN ({ids})
-                """.format(
-                    table=self._table,
-                    field=field,
-                    ids=", ".join(["%s"] * len(custom_ids)),
-                )
-                query.add_where(extra_clause, where_params=custom_ids.ids)
-
-    @api.model
-    def _apply_ir_rules(self, query, mode="read"):
-        super(DmsSecurityMixin, self)._apply_ir_rules(query, mode=mode)
-        self._apply_access_groups(query, mode=mode)
-
-    def _get_ids_without_access_groups(self, operation):
-        sql_query = sql.SQL(
-            """
-            SELECT id
-            FROM {self_table} a
-            WHERE NOT EXISTS (
-                SELECT 1
-                FROM {rel_table} r
-                JOIN dms_access_group g ON r.gid = g.id AND r.aid = a.id
-                WHERE r.aid = ANY (%(subset_ids)s)
-            )
-            """
-        )
-        sql_query = sql_query.format(
-            self_table=sql.Identifier(self._table),
-            rel_table=sql.Identifier(self._table + "_complete_groups_rel"),
-        )
-        self.env.cr.execute(sql_query, {"subset_ids": self.ids})
-        return list(map(lambda val: val[0], self.env.cr.fetchall()))
-
-    @api.model
-    def _search_permission_read(self, operator, operand):
-        if operator == "=" and operand:
-            return [("id", "in", self.search([])._filter_access_ids("read"))]
-        return [("id", "not in", self.search([])._filter_access_ids("read"))]
-
-    @api.model
-    def _search_permission_create(self, operator, operand):
-        if operator == "=" and operand:
-            return [("id", "in", self.search([])._filter_access_ids("create"))]
-        return [("id", "not in", self.search([])._filter_access_ids("create"))]
-
-    @api.model
-    def _search_permission_write(self, operator, operand):
-        if operator == "=" and operand:
-            return [("id", "in", self.search([])._filter_access_ids("write"))]
-        return [("id", "not in", self.search([])._filter_access_ids("write"))]
-
-    @api.model
-    def _search_permission_unlink(self, operator, operand):
-        if operator == "=" and operand:
-            return [("id", "in", self.search([])._filter_access_ids("unlink"))]
-        return [("id", "not in", self.search([])._filter_access_ids("unlink"))]
-
-    def _compute_permissions_read(self):
-        records = self._filter_access("read")
-        for record in records:
-            record.update({"permission_read": True})
-        for record in self - records:
-            record.update({"permission_read": False})
-
-    def _compute_permissions_create(self):
-        records = self._filter_access("create")
-        for record in records:
-            record.update({"permission_create": True})
-        for record in self - records:
-            record.update({"permission_create": False})
-
-    def _compute_permissions_write(self):
-        records = self._filter_access("write")
-        for record in records:
-            record.update({"permission_write": True})
-        for record in self - records:
-            record.update({"permission_write": False})
-
-    def _compute_permissions_unlink(self):
-        records = self._filter_access("unlink")
-        for record in records:
-            record.update({"permission_unlink": True})
-        for record in self - records:
-            record.update({"permission_unlink": False})
-
-    def check_access(self, operation, raise_exception=False):
-        try:
-            access_right = self.check_access_rights(operation, raise_exception)
-            access_rule = self.check_access_rule(operation) is None
-            access_group = self.check_access_groups(operation) is None
-            return access_right and access_rule and access_group
-        except AccessError:
-            if raise_exception:
-                raise
-            return False
-
-    def check_access_groups(self, operation):
-        if self.env.user.id == SUPERUSER_ID:
-            return None
-        group_ids = list(
-            set(self.ids) - set(self._get_ids_without_access_groups(operation))
-        )
-        if group_ids:
-            sql_query = sql.SQL(
-                """
-                SELECT r.aid, perm_read, perm_create, perm_write, perm_unlink
-                FROM {rel_table} r
-                JOIN dms_access_group g ON r.gid = g.id
-                JOIN dms_access_group_users_rel u ON r.gid = u.gid
-                WHERE r.aid = ANY (%(group_ids)s) AND u.uid = %(uid)s;
-                """
-            ).format(
-                rel_table=sql.Identifier(self._table + "_complete_groups_rel"),
-            )
-            self.env.cr.execute(
-                sql_query, {"group_ids": group_ids, "uid": self.env.user.id}
-            )
-            result = defaultdict(list)
-            for val in self.env.cr.dictfetchall():
-                result[val["aid"]].append(val["perm_%s" % operation])
-            if (
-                len(result.keys()) < len(group_ids)
-                or not all(list(map(lambda val: any(val), result.values())))
-            ) and not self.check_access(operation):
-                raise AccessError(
-                    _(
-                        "The requested operation cannot be completed due "
-                        "to group security restrictions. "
-                        "Please contact your system administrator."
-                        "\n\n(Document type: %s, Operation: %s)"
-                    )
-                    % (self._description, operation)
-                )
-
-    def filter_access_groups(self, operation):
-        if self.env.user.id == SUPERUSER_ID:
-            return self
-        ids_with_access = self._get_ids_without_access_groups(operation)
-        group_ids = list(set(self.ids) - set(ids_with_access))
-        if group_ids:
-            sql_query = sql.SQL(
-                """
-                SELECT r.aid
-                FROM {rel_table} r
-                JOIN dms_access_group g ON r.gid = g.id
-                JOIN dms_access_group_users_rel u ON r.gid = u.gid
-                WHERE
-                    r.aid = ANY (%(ids)s) AND
-                    u.uid = %(uid)s AND (
-                        (%(operation)s = 'read' AND g.perm_read) OR
-                        (%(operation)s = 'create' AND g.perm_create) OR
-                        (%(operation)s = 'write' AND g.perm_write) OR
-                        (%(operation)s = 'unlink' AND g.perm_unlink)
-                    )
-            """
-            ).format(
-                rel_table=sql.Identifier(self._table + "_complete_groups_rel"),
-            )
-            self.env.cr.execute(
-                sql_query,
-                {"ids": group_ids, "uid": self.env.user.id, "operation": operation},
-            )
-            ids_with_access += list(map(lambda val: val[0], self.env.cr.fetchall()))
-        return self & self.browse(ids_with_access)
-
-    def _get_directory_ids_with_res_model_without_access(self, operation):
-        """
-        It's necessary to get all directories with res_model related and check
-        if access to related record.
-        Context use_res_model_without_access=False is used to skip some
-        part of functions that use these function and prevent recursion error.
-        """
-        return (
-            self.env["dms.directory"]
-            .with_context(use_res_model_without_access=False)
-            .search(
-                [
-                    ("res_model", "!=", False),
-                    ("storage_id_inherit_access_from_parent_record", "=", True),
-                ]
-            )
-            .filtered(lambda x: not x.check_access("read"))
-        )
-
-    def _write(self, vals):
-        self.check_access_groups("write")
-        return super(DmsSecurityMixin, self)._write(vals)
-
-    def unlink(self):
-        self.check_access_groups("unlink")
-        return super(DmsSecurityMixin, self).unlink()
-
-    @api.depends("group_ids")
-    def _compute_groups(self):
+    @api.depends("res_model", "res_id")
+    def _compute_record_ref(self):
         for record in self:
-            record.complete_group_ids = record.group_ids
+            record.record_ref = False
+            if record.res_model and record.res_id:
+                record.record_ref = "{},{}".format(record.res_model, record.res_id)
+
+    def _compute_permissions(self):
+        """Get permissions for the current record.
+
+        ⚠ Not very performant; only display field on form views.
+        """
+        # Superuser unrestricted 🦸
+        if self.env.su:
+            self.update(
+                {
+                    "permission_create": True,
+                    "permission_read": True,
+                    "permission_unlink": True,
+                    "permission_write": True,
+                }
+            )
+            return
+        # Update according to presence when applying ir.rule
+        creatable = self._filter_access_rules("create")
+        readable = self._filter_access_rules("read")
+        unlinkable = self._filter_access_rules("unlink")
+        writeable = self._filter_access_rules("write")
+        for one in self:
+            one.update(
+                {
+                    "permission_create": bool(one & creatable),
+                    "permission_read": bool(one & readable),
+                    "permission_unlink": bool(one & unlinkable),
+                    "permission_write": bool(one & writeable),
+                }
+            )
+
+    @api.model
+    def _get_domain_by_inheritance(self, operation):
+        """Get domain for inherited accessible records."""
+        if self.env.su:
+            return []
+        inherited_access_field = "storage_id_inherit_access_from_parent_record"
+        if self._name != "dms.directory":
+            inherited_access_field = "{}.{}".format(
+                self._directory_field,
+                inherited_access_field,
+            )
+        inherited_access_domain = [(inherited_access_field, "=", True)]
+        domains = []
+        # Get all used related records
+        related_groups = self.sudo().read_group(
+            domain=inherited_access_domain + [("res_model", "!=", False)],
+            fields=["res_id:array_agg"],
+            groupby=["res_model"],
+        )
+        for group in related_groups:
+            try:
+                model = self.env[group["res_model"]]
+            except KeyError:
+                # Model not registered. This is normal if you are upgrading the
+                # database. Otherwise, you probably have garbage DMS data.
+                # These records will be accessible by DB users only.
+                domains.append(
+                    [
+                        ("res_model", "=", group["res_model"]),
+                        (True, "=", self.env.user.has_group("base.group_user")),
+                    ]
+                )
+                continue
+            # Check model access only once per batch
+            if not model.check_access_rights(operation, raise_exception=False):
+                continue
+            domains.append([("res_model", "=", model._name), ("res_id", "=", False)])
+            # Check record access in batch too
+            group_ids = [i for i in group["res_id"] if i]  # Hack to remove None res_id
+            related_ok = model.browse(group_ids)._filter_access_rules(operation)
+            if not related_ok:
+                continue
+            domains.append(
+                [("res_model", "=", model._name), ("res_id", "in", related_ok.ids)]
+            )
+        result = inherited_access_domain + OR(domains)
+        return result
+
+    @api.model
+    def _get_access_groups_query(self, operation):
+        """Return the query to select access groups."""
+        operation_check = {
+            "create": "AND dag.perm_inclusive_create",
+            "read": "",
+            "unlink": "AND dag.perm_inclusive_unlink",
+            "write": "AND dag.perm_inclusive_write",
+        }[operation]
+        select = """
+            SELECT
+                dir_group_rel.aid
+            FROM
+                dms_directory_complete_groups_rel AS dir_group_rel
+                INNER JOIN dms_access_group AS dag
+                    ON dir_group_rel.gid = dag.id
+                INNER JOIN dms_access_group_users_rel AS users
+                    ON users.gid = dag.id
+            WHERE
+                users.uid = %s {}
+            """.format(
+            operation_check
+        )
+        return (select, (self.env.uid,))
+
+    @api.model
+    def _get_domain_by_access_groups(self, operation):
+        """Get domain for records accessible applying DMS access groups."""
+        result = [
+            (
+                "%s.storage_id_inherit_access_from_parent_record"
+                % self._directory_field,
+                "=",
+                False,
+            ),
+            (
+                self._directory_field,
+                "inselect",
+                self._get_access_groups_query(operation),
+            ),
+        ]
+        return result
+
+    @api.model
+    def _get_permission_domain(self, operator, value, operation):
+        """Abstract logic for searching computed permission fields."""
+        _self = self
+        # HACK ir.rule domain is always computed with sudo, so if this check is
+        # true, we can assume safely that you're checking permissions
+        if self.env.su and value == self.env.uid:
+            _self = self.sudo(False)
+            value = bool(value)
+        # Tricky one, to know if you want to search
+        # positive or negative access
+        positive = (operator not in NEGATIVE_TERM_OPERATORS) == bool(value)
+        if _self.env.su:
+            # You're SUPERUSER_ID
+            return TRUE_DOMAIN if positive else FALSE_DOMAIN
+        # Obtain and combine domains
+        result = OR(
+            [
+                _self._get_domain_by_access_groups(operation),
+                _self._get_domain_by_inheritance(operation),
+            ]
+        )
+        if not positive:
+            result.insert(0, "!")
+        return result
+
+    @api.model
+    def _search_permission_create(self, operator, value):
+        return self._get_permission_domain(operator, value, "create")
+
+    @api.model
+    def _search_permission_read(self, operator, value):
+        return self._get_permission_domain(operator, value, "read")
+
+    @api.model
+    def _search_permission_unlink(self, operator, value):
+        return self._get_permission_domain(operator, value, "unlink")
+
+    @api.model
+    def _search_permission_write(self, operator, value):
+        return self._get_permission_domain(operator, value, "write")

--- a/dms/models/dms_security_mixin.py
+++ b/dms/models/dms_security_mixin.py
@@ -130,7 +130,7 @@ class DmsSecurityMixin(models.AbstractModel):
             domains.append([("res_model", "=", model._name), ("res_id", "=", False)])
             # Check record access in batch too
             group_ids = [i for i in group["res_id"] if i]  # Hack to remove None res_id
-            related_ok = model.browse(group_ids)._filter_access_rules(operation)
+            related_ok = model.browse(group_ids)._filter_access_rules_python(operation)
             if not related_ok:
                 continue
             domains.append(
@@ -223,3 +223,29 @@ class DmsSecurityMixin(models.AbstractModel):
     @api.model
     def _search_permission_write(self, operator, value):
         return self._get_permission_domain(operator, value, "write")
+
+    def _filter_access_rules_python(self, operation):
+        # Only kept to not break inheritance; see next comment
+        result = super()._filter_access_rules_python(operation)
+        # HACK Always fall back to applying rules by SQL.
+        # Upstream `_filter_acccess_rules_python()` doesn't use computed fields
+        # search methods. Thus, it will take the `[('permission_{operation}',
+        # '=', user.id)]` rule literally. Obviously that will always fail
+        # because `self[f"permission_{operation}"]` will always be a `bool`,
+        # while `user.id` will always be an `int`.
+        result |= self._filter_access_rules(operation)
+        return result
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        # Create as sudo to avoid testing creation permissions before DMS security
+        # groups are attached (otherwise nobody would be able to create)
+        res = super(DmsSecurityMixin, self.sudo()).create(vals_list)
+        # Need to flush now, so all groups are stored in DB and the SELECT used
+        # to check access works
+        res.flush()
+        # Go back to original sudo state and check we really had creation permission
+        res = res.sudo(self.env.su)
+        res.check_access_rights("create")
+        res.check_access_rule("create")
+        return res

--- a/dms/models/ir_attachment.py
+++ b/dms/models/ir_attachment.py
@@ -39,13 +39,13 @@ class IrAttachment(models.Model):
         for attachment in self:
             if not attachment.res_model or not attachment.res_id:
                 continue
-            directories = self.sudo()._get_dms_directories(
+            directories = attachment._get_dms_directories(
                 attachment.res_model, attachment.res_id
             )
             if not directories:
                 attachment._dms_directories_create()
                 # Get dms_directories again (with items previously created)
-                directories = self.sudo()._get_dms_directories(
+                directories = attachment._get_dms_directories(
                     attachment.res_model, attachment.res_id
                 )
             # Auto-create_files (if not exists)

--- a/dms/readme/ROADMAP.rst
+++ b/dms/readme/ROADMAP.rst
@@ -4,3 +4,4 @@
 - Add a migration procedure for converting an storage to attachment one for populating existing records with attachments as folders
 - Add a link from attachment view in chatter to linked documents
 - If Inherit permissions from related record (the inherit_access_from_parent_record field from storage) is changed when directories already exist, inconsistencies may occur because groups defined in the directories and subdirectories will still exist, all groups in these directories should be removed before changing.
+- Since portal users can read ``dms.storage`` records, if your module extends this model to another storage backend that needs using secrets, remember to forbid access to the secrets fields by other means. It would be nice to be able to remove that rule at some point.

--- a/dms/security/ir.model.access.csv
+++ b/dms/security/ir.model.access.csv
@@ -3,6 +3,7 @@ id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink
 access_dms_tag_user,dms_tag_user,model_dms_tag,group_dms_user,1,1,1,1
 access_dms_category_user,dms_category_user,model_dms_category,group_dms_user,1,1,1,1
 
+access_dms_storage_portal,dms_storage_portal,model_dms_storage,base.group_portal,1,0,0,0
 access_dms_storage_user,dms_storage_user,model_dms_storage,group_dms_user,1,0,0,0
 access_dms_storage_manager,dms_storage_manager,model_dms_storage,group_dms_manager,1,1,1,1
 

--- a/dms/security/security.xml
+++ b/dms/security/security.xml
@@ -48,6 +48,19 @@
             name="domain_force"
         >['|',('company_id','=',False),('company_id','in',company_ids)]</field>
     </record>
+    <record id="rule_file_locked" model="ir.rule">
+        <field name="name">Locked files are only modified by locker user.</field>
+        <field name="model_id" ref="model_dms_file" />
+        <field name="groups" eval="[(4, ref('base.group_user'))]" />
+        <field name="global" eval="True" />
+        <field name="perm_read" eval="0" />
+        <field name="perm_create" eval="1" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_unlink" eval="1" />
+        <field
+            name="domain_force"
+        >['|', ('locked_by', '=', False), ('locked_by', '=', user.id)]</field>
+    </record>
     <record id="rule_security_groups_user" model="ir.rule">
         <field name="name">User can only edit and delete their own groups.</field>
         <field name="model_id" ref="model_dms_access_group" />
@@ -68,34 +81,109 @@
         <field name="perm_unlink" eval="1" />
         <field name="domain_force">[(1 ,'=', 1)]</field>
     </record>
-    <record id="rule_security_dms_directory" model="ir.rule">
-        <field
-            name="name"
-        >Dms Directories with dms group (will be filtered later by code)</field>
-        <field name="model_id" ref="model_dms_directory" />
+    <!-- Forbid lower groups access to hidden storage -->
+    <record id="rule_forbid_hidden_storage" model="ir.rule">
+        <field name="name">Basic users cannot access hidden storage</field>
+        <field name="model_id" ref="model_dms_storage" />
         <field
             name="groups"
-            eval="[(4, ref('base.group_user')),(4, ref('base.group_portal'))]"
+            eval="[(4, ref('base.group_portal')), (4, ref('group_dms_user'))]"
         />
         <field name="perm_read" eval="1" />
-        <field name="perm_create" eval="0" />
-        <field name="perm_write" eval="0" />
-        <field name="perm_unlink" eval="0" />
-        <field name="domain_force">[(1,'=',1)]</field>
+        <field name="perm_create" eval="1" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_unlink" eval="1" />
+        <field name="domain_force">[('is_hidden', '=', False)]</field>
     </record>
-    <record id="rule_security_dms_file" model="ir.rule">
-        <field
-            name="name"
-        >Dms Files with dms group (will be filtered later by code)</field>
-        <field name="model_id" ref="model_dms_file" />
-        <field
-            name="groups"
-            eval="[(4, ref('base.group_user')),(4, ref('base.group_portal'))]"
-        />
+    <record id="rule_allow_hidden_storage" model="ir.rule">
+        <field name="name">Managers can access hidden storage</field>
+        <field name="model_id" ref="model_dms_storage" />
+        <field name="groups" eval="[(4, ref('group_dms_manager'))]" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_create" eval="1" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_unlink" eval="1" />
+        <field name="domain_force">[('is_hidden', '=', True)]</field>
+    </record>
+    <!-- These rules leverage computed permission management -->
+    <record id="rule_directory_computed_create" model="ir.rule">
+        <field name="name">Apply computed create permissions.</field>
+        <field name="model_id" ref="model_dms_directory" />
+        <field name="global" eval="True" />
+        <field name="perm_read" eval="0" />
+        <field name="perm_create" eval="1" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_unlink" eval="0" />
+        <field name="domain_force">[('permission_create', '=', user.id)]</field>
+    </record>
+    <record id="rule_directory_computed_read" model="ir.rule">
+        <field name="name">Apply computed read permissions.</field>
+        <field name="model_id" ref="model_dms_directory" />
+        <field name="global" eval="True" />
         <field name="perm_read" eval="1" />
         <field name="perm_create" eval="0" />
         <field name="perm_write" eval="0" />
         <field name="perm_unlink" eval="0" />
-        <field name="domain_force">[(1,'=',1)]</field>
+        <field name="domain_force">[('permission_read', '=', user.id)]</field>
+    </record>
+    <record id="rule_directory_computed_unlink" model="ir.rule">
+        <field name="name">Apply computed unlink permissions.</field>
+        <field name="model_id" ref="model_dms_directory" />
+        <field name="global" eval="True" />
+        <field name="perm_read" eval="0" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_unlink" eval="1" />
+        <field name="domain_force">[('permission_unlink', '=', user.id)]</field>
+    </record>
+    <record id="rule_directory_computed_write" model="ir.rule">
+        <field name="name">Apply computed write permissions.</field>
+        <field name="model_id" ref="model_dms_directory" />
+        <field name="global" eval="True" />
+        <field name="perm_read" eval="0" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_unlink" eval="0" />
+        <field name="domain_force">[('permission_write', '=', user.id)]</field>
+    </record>
+    <record id="rule_file_computed_create" model="ir.rule">
+        <field name="name">Apply computed create permissions.</field>
+        <field name="model_id" ref="model_dms_file" />
+        <field name="global" eval="True" />
+        <field name="perm_read" eval="0" />
+        <field name="perm_create" eval="1" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_unlink" eval="0" />
+        <field name="domain_force">[('permission_create', '=', user.id)]</field>
+    </record>
+    <record id="rule_file_computed_read" model="ir.rule">
+        <field name="name">Apply computed read permissions.</field>
+        <field name="model_id" ref="model_dms_file" />
+        <field name="global" eval="True" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_unlink" eval="0" />
+        <field name="domain_force">[('permission_read', '=', user.id)]</field>
+    </record>
+    <record id="rule_file_computed_unlink" model="ir.rule">
+        <field name="name">Apply computed unlink permissions.</field>
+        <field name="model_id" ref="model_dms_file" />
+        <field name="global" eval="True" />
+        <field name="perm_read" eval="0" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_unlink" eval="1" />
+        <field name="domain_force">[('permission_unlink', '=', user.id)]</field>
+    </record>
+    <record id="rule_file_computed_write" model="ir.rule">
+        <field name="name">Apply computed write permissions.</field>
+        <field name="model_id" ref="model_dms_file" />
+        <field name="global" eval="True" />
+        <field name="perm_read" eval="0" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_unlink" eval="0" />
+        <field name="domain_force">[('permission_write', '=', user.id)]</field>
     </record>
 </odoo>

--- a/dms/tests/common.py
+++ b/dms/tests/common.py
@@ -12,7 +12,7 @@ import uuid
 
 from odoo import SUPERUSER_ID, _
 from odoo.modules.module import get_module_resource
-from odoo.tests import common
+from odoo.tests import Form, common
 from odoo.tools import convert_file
 
 _path = os.path.dirname(os.path.dirname(__file__))
@@ -154,6 +154,7 @@ class DocumentsBaseCase(common.TransactionCase):
         self.super_uid = SUPERUSER_ID
         self.admin_uid = self.browse_ref("base.user_admin").id
         self.demo_uid = self.browse_ref("base.user_demo").id
+        self.access_group_demo = self.browse_ref("dms.access_group_01_demo")
         self.storage = self.env["dms.storage"]
         self.directory = self.env["dms.directory"]
         self.file = self.env["dms.file"]
@@ -201,37 +202,27 @@ class DocumentsBaseCase(common.TransactionCase):
         model = self.directory.sudo() if sudo else self.directory
         if not storage and not directory:
             storage = self.create_storage(sudo=sudo)
+        record = Form(model)
+        record.name = uuid.uuid4().hex
+        record.is_root_directory = True
+        record.res_model = res_model
         if directory:
-            return model.create(
-                {
-                    "name": uuid.uuid4().hex,
-                    "is_root_directory": False,
-                    "res_model": res_model,
-                    "parent_id": directory.id,
-                    "storage_id": directory.storage_id.id,
-                }
-            )
-        return model.create(
-            {
-                "name": uuid.uuid4().hex,
-                "is_root_directory": True,
-                "res_model": res_model,
-                "storage_id": storage.id,
-                "parent_id": False,
-            }
-        )
+            record.is_root_directory = False
+            record.parent_id = directory
+        if storage and not storage.inherit_access_from_parent_record:
+            record.storage_id = storage
+            record.group_ids.add(self.access_group_demo)
+        return record.save()
 
     def create_file(self, directory=False, content=False, storage=False, sudo=False):
         model = self.file.sudo() if sudo else self.file
         if not directory:
             directory = self.create_directory(storage=storage, sudo=sudo)
-        return model.create(
-            {
-                "name": uuid.uuid4().hex,
-                "directory_id": directory.id,
-                "content": content or self.content_base64(),
-            }
-        )
+        record = Form(model)
+        record.name = uuid.uuid4().hex
+        record.directory_id = directory
+        record.content = content or self.content_base64()
+        return record.save()
 
     def create_attachment(
         self, name, res_model=False, res_id=False, content=False, sudo=False

--- a/dms/tests/test_file.py
+++ b/dms/tests/test_file.py
@@ -32,11 +32,7 @@ class FileFilestoreTestCase(FileTestCase):
             }
         )
         group_a = self.env["dms.access.group"].create(
-            {
-                "name": "Group A",
-                "perm_read": True,
-                "explicit_user_ids": [(6, 0, [user_a.id])],
-            }
+            {"name": "Group A", "explicit_user_ids": [(6, 0, [user_a.id])]}
         )
         root_directory_a = self.env["dms.directory"].create(
             {
@@ -55,12 +51,7 @@ class FileFilestoreTestCase(FileTestCase):
                 "inherit_group_ids": True,
             }
         )
-        dms_file = self.env.ref("dms.file_13_demo").copy(
-            {
-                "name": "Test file directory %s" % (sub_directory_x.id),
-                "directory_id": sub_directory_x.id,
-            }
-        )
+        dms_file = self.create_file(directory=sub_directory_x)
         dms_files = self.env["dms.file"].with_user(user_a).search([])
         self.assertTrue(self.env.ref("dms.file_13_demo") not in dms_files)
         self.assertTrue(dms_file in dms_files)

--- a/dms/tests/test_file_database.py
+++ b/dms/tests/test_file_database.py
@@ -34,7 +34,7 @@ class FileTestCase(DocumentsBaseCase):
     @multi_users(lambda self: self.multi_users(), callback="_setup_test_data")
     def test_create_file(self):
         root_directory = self.create_directory(storage=self.new_storage)
-        self.create_file(root_directory)
+        self.create_file(directory=root_directory)
         sub_directory = self.create_directory(directory=root_directory)
         self.create_file(sub_directory)
         self.assertEqual(root_directory.count_total_files, 2)

--- a/dms/tests/test_portal.py
+++ b/dms/tests/test_portal.py
@@ -6,6 +6,7 @@ import base64
 import odoo.tests
 
 
+@odoo.tests.tagged("post_install", "-at_install")
 class TestDmsPortal(odoo.tests.HttpCase):
     def setUp(self):
         super().setUp()
@@ -57,12 +58,7 @@ class TestDmsPortal(odoo.tests.HttpCase):
     def test_tour(self):
         for tour in ("dms_portal_mail_tour", "dms_portal_partners_tour"):
             with self.subTest(tour=tour):
-                self.start_tour(
-                    "/my",
-                    "odoo.__DEBUG__.services['web_tour.tour'].run('%s')" % tour,
-                    "odoo.__DEBUG__.services['web_tour.tour'].tours.%s.ready" % tour,
-                    login="portal",
-                )
+                self.start_tour("/", tour, login="portal")
 
     def test_permission_flag(self):
         """Assert portal partner directory and files permissions."""

--- a/dms/tests/test_storage_attachment.py
+++ b/dms/tests/test_storage_attachment.py
@@ -1,4 +1,5 @@
 # Copyright 2021 Tecnativa - Víctor Martínez
+# Copyright 2021 Tecnativa - João Marques
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from .common import DocumentsBaseCase
@@ -17,10 +18,44 @@ class StorageAttachmentTestCase(DocumentsBaseCase):
                 "groups_id": [(6, 0, [self.env.ref("base.group_user").id])],
             }
         )
-        user_admin = self.browse_ref("base.user_admin")
-        self.user_demo = self.browse_ref("base.user_demo")
-        (user_admin + self.user_demo).write(
-            {"groups_id": [(3, self.ref("base.group_private_addresses"))]}
+        self.user_demo = self.env["res.users"].create(
+            {
+                "name": "User Base",
+                "login": "user_demo",
+                "groups_id": [
+                    (
+                        6,
+                        0,
+                        [
+                            self.env.ref("base.group_partner_manager").id,
+                            self.env.ref("base.group_user").id,
+                            self.env.ref("base.group_no_one").id,
+                            self.env.ref("dms.group_dms_user").id,
+                        ],
+                    )
+                ],
+            }
+        )
+        self.user_admin = self.env["res.users"].create(
+            {
+                "name": "User Admin",
+                "login": "user_admin",
+                "groups_id": [
+                    (
+                        6,
+                        0,
+                        [
+                            self.env.ref("base.group_erp_manager").id,
+                            self.env.ref("base.group_partner_manager").id,
+                            self.env.ref("base.group_user").id,
+                            self.env.ref("dms.group_dms_manager").id,
+                            self.env.ref("base.group_system").id,
+                            self.env.ref("base.group_no_one").id,
+                            self.env.ref("dms.group_dms_user").id,
+                        ],
+                    )
+                ],
+            }
         )
 
     def _create_attachment(self, name, uid):
@@ -32,11 +67,11 @@ class StorageAttachmentTestCase(DocumentsBaseCase):
         ).with_user(uid)
 
     def test_storage_attachment(self):
-        self._create_attachment("demo.txt", self.admin_uid)
+        self._create_attachment("demo.txt", self.user_admin.id)
         self.assertTrue(
             self.storage.storage_file_ids.filtered(lambda x: x.name == "demo.txt")
         )
-        directory_id = self.directory.with_user(self.admin_uid).search(
+        directory_id = self.directory.with_user(self.user_admin.id).search(
             [
                 ("storage_id", "=", self.storage.id),
                 ("res_model", "=", self.model_res_partner.model),
@@ -48,7 +83,7 @@ class StorageAttachmentTestCase(DocumentsBaseCase):
         file_01 = self.create_file(
             directory=directory_id,
             storage=directory_id.storage_id,
-        ).with_user(self.admin_uid)
+        ).with_user(self.user_admin.id)
         self.assertEqual(file_01.storage_id, self.storage)
         self.assertEqual(file_01.storage_id.save_type, "attachment")
         self.assertEqual(file_01.save_type, "database")
@@ -59,26 +94,25 @@ class StorageAttachmentTestCase(DocumentsBaseCase):
         self.assertFalse(directory_id.exists())
 
     def test_storage_attachment_directory_record_ref_access(self):
-        self._create_attachment("demo.txt", self.admin_uid)
-        directory_id = self.directory.with_user(self.admin_uid).search(
+        self._create_attachment("demo.txt", self.user_admin.id)
+        directory_id = self.directory.with_user(self.user_admin.id).search(
             [
                 ("storage_id", "=", self.storage.id),
                 ("res_model", "=", self.model_res_partner.model),
                 ("res_id", "=", self.partner.id),
             ]
         )
-        self.assertTrue(directory_id.with_user(self.admin_uid).permission_read)
-        self.assertTrue(directory_id.with_user(self.demo_uid).permission_read)
+        self.assertTrue(directory_id.with_user(self.user_admin.id).permission_read)
+        self.assertTrue(directory_id.with_user(self.user_demo.id).permission_read)
         self.assertTrue(directory_id.with_user(self.user.id).permission_read)
         self.assertEqual(self.partner.type, "contact")
         self.partner.sudo().write({"type": "private"})
         self.assertEqual(self.partner.type, "private")
         self.assertTrue(directory_id.sudo().permission_read)
-        directory_id.with_user(self.admin_uid).invalidate_cache()
-        self.assertFalse(directory_id.with_user(self.admin_uid).permission_read)
-        directory_id.with_user(self.demo_uid).invalidate_cache()
-        self.assertFalse(directory_id.with_user(self.demo_uid).permission_read)
-        directory_id.with_user(self.user).invalidate_cache()
+        directory_id.invalidate_cache()
+        self.assertFalse(directory_id.with_user(self.user_admin.id).permission_read)
+        directory_id.invalidate_cache()
+        self.assertFalse(directory_id.with_user(self.user_demo.id).permission_read)
         self.assertFalse(directory_id.with_user(self.user.id).permission_read)
         # user can access self.partner
         self.user_demo.write(
@@ -95,4 +129,4 @@ class StorageAttachmentTestCase(DocumentsBaseCase):
                 ]
             }
         )
-        self.assertTrue(directory_id.with_user(self.demo_uid).permission_read)
+        self.assertTrue(directory_id.with_user(self.user_demo.id).permission_read)

--- a/dms/views/directory.xml
+++ b/dms/views/directory.xml
@@ -574,7 +574,6 @@
                             <field name="group_ids">
                                 <tree string="Groups">
                                     <field name="name" />
-                                    <field name="perm_read" />
                                     <field name="perm_create" />
                                     <field name="perm_write" />
                                     <field name="perm_unlink" />
@@ -588,7 +587,6 @@
                             <field name="complete_group_ids">
                                 <tree string="Complete Groups">
                                     <field name="name" />
-                                    <field name="perm_read" />
                                     <field name="perm_create" />
                                     <field name="perm_write" />
                                     <field name="perm_unlink" />

--- a/dms/views/dms_access_groups_views.xml
+++ b/dms/views/dms_access_groups_views.xml
@@ -12,7 +12,6 @@
         <field name="arch" type="xml">
             <tree string="Groups">
                 <field name="name" />
-                <field name="perm_read" />
                 <field name="perm_create" />
                 <field name="perm_write" />
                 <field name="perm_unlink" />
@@ -44,7 +43,6 @@
                     <group string="Settings">
                         <group>
                             <field name="perm_create" />
-                            <field name="perm_read" />
                         </group>
                         <group>
                             <field name="perm_write" />
@@ -84,7 +82,6 @@
                             <field name="child_group_ids">
                                 <tree string="Groups">
                                     <field name="name" />
-                                    <field name="perm_read" />
                                     <field name="perm_create" />
                                     <field name="perm_write" />
                                     <field name="perm_unlink" />


### PR DESCRIPTION
Related to https://github.com/OCA/dms/pull/107 + Adapt 14.0

- Remove `perm_read` field from `dms.access.group`. It is redundant to the mere existence of the group. Otherwise, users could be able to create, write or unlink records that they cannot read. To avoid confusion, it is removed.
- Add portal group access to mails directory, to make one test pass. This was a false positive before.
- Forbid `dms.access.group` recursiveness.
- Compute inclusive permissions in `dms.access.group`, which combine current group with parent group permissions.
- Rely on domain search of `permission_{create,read,unlink,write}` in `dms.directory` and `dms.file` when checking those accesses to records. These search methods are improved to reflect permission reality and add it to the domain.
- Added a hack to workaround situations where the current context user is superuser, but it's actually checking for other user permissions.
- These checks are added as normal `ir.rule` records.
- To create something in a directory, you need create access in the parent directory.
- For other operations, and only in subdirs, the own dir access is checked.
- Batch operations when checking inherited permissions.
- Remove many custom methods to check access, now that we use ORM's.
- Fix custom cascade dir unlink.
- Use `consteq()` when checking access tokens, for security.
- Remove duplicated security computations from `dms.directory` and `dms.file`. Use proper inheritance.
- Use `ir.rule` for checking locked files.
- Add or fix tests for new permissions model.
- [NEW] Fix prevent error related to mail_message parent not exists in some cases (directory)
- Fix tests for environments that add other groups to base users https://github.com/OCA/dms/pull/116

Please @Yajo can you review it?

@Tecnativa TT29847