### PR TITLE
[12.0][FIX] dms: Fix tests for environments that add other groups to base users

### DIFF
--- a/dms/tests/test_storage_attachment.py
+++ b/dms/tests/test_storage_attachment.py
@@ -1,4 +1,5 @@
 # Copyright 2021 Tecnativa - Víctor Martínez
+# Copyright 2021 Tecnativa - João Marques
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from .common import DocumentsBaseCase
@@ -17,10 +18,44 @@ class StorageAttachmentTestCase(DocumentsBaseCase):
                 "groups_id": [(6, 0, [self.env.ref("base.group_user").id])],
             }
         )
-        user_admin = self.browse_ref("base.user_admin")
-        self.user_demo = self.browse_ref("base.user_demo")
-        (user_admin + self.user_demo).write(
-            {"groups_id": [(3, self.ref("base.group_private_addresses"))]}
+        self.user_demo = self.env["res.users"].create(
+            {
+                "name": "User Base",
+                "login": "user_demo",
+                "groups_id": [
+                    (
+                        6,
+                        0,
+                        [
+                            self.env.ref("base.group_partner_manager").id,
+                            self.env.ref("base.group_user").id,
+                            self.env.ref("base.group_no_one").id,
+                            self.env.ref("dms.group_dms_user").id,
+                        ],
+                    )
+                ],
+            }
+        )
+        self.user_admin = self.env["res.users"].create(
+            {
+                "name": "User Admin",
+                "login": "user_admin",
+                "groups_id": [
+                    (
+                        6,
+                        0,
+                        [
+                            self.env.ref("base.group_erp_manager").id,
+                            self.env.ref("base.group_partner_manager").id,
+                            self.env.ref("base.group_user").id,
+                            self.env.ref("dms.group_dms_manager").id,
+                            self.env.ref("base.group_system").id,
+                            self.env.ref("base.group_no_one").id,
+                            self.env.ref("dms.group_dms_user").id,
+                        ],
+                    )
+                ],
+            }
         )
 
     def _create_attachment(self, name, uid):
@@ -32,9 +67,9 @@ class StorageAttachmentTestCase(DocumentsBaseCase):
         ).sudo(uid)
 
     def test_storage_attachment(self):
-        self._create_attachment("demo.txt", self.admin_uid)
+        self._create_attachment("demo.txt", self.user_admin.id)
         self.assertEqual(self.storage.count_storage_files, 1)
-        directory_id = self.directory.sudo(self.admin_uid).search(
+        directory_id = self.directory.sudo(self.user_admin.id).search(
             [
                 ("storage_id", "=", self.storage.id),
                 ("res_model", "=", self.model_res_partner.model),
@@ -47,7 +82,7 @@ class StorageAttachmentTestCase(DocumentsBaseCase):
             context={"default_res_model": self.model_res_partner.model},
             directory=directory_id,
             storage=directory_id.storage_id,
-        ).sudo(self.admin_uid)
+        ).sudo(self.user_admin.id)
         self.assertEqual(file_01.storage_id, self.storage)
         self.assertEqual(file_01.storage_id.save_type, "attachment")
         self.assertEqual(file_01.save_type, "database")
@@ -58,24 +93,24 @@ class StorageAttachmentTestCase(DocumentsBaseCase):
         self.assertFalse(directory_id.exists())
 
     def test_storage_attachment_directory_record_ref_access(self):
-        self._create_attachment("demo.txt", self.admin_uid)
-        directory_id = self.directory.sudo(self.admin_uid).search(
+        self._create_attachment("demo.txt", self.user_admin.id)
+        directory_id = self.directory.sudo(self.user_admin.id).search(
             [
                 ("storage_id", "=", self.storage.id),
                 ("res_model", "=", self.model_res_partner.model),
                 ("res_id", "=", self.partner.id),
             ]
         )
-        self.assertTrue(directory_id.sudo(self.admin_uid).permission_read)
-        self.assertTrue(directory_id.sudo(self.demo_uid).permission_read)
+        self.assertTrue(directory_id.sudo(self.user_admin.id).permission_read)
+        self.assertTrue(directory_id.sudo(self.user_demo.id).permission_read)
         self.assertTrue(directory_id.sudo(self.user.id).permission_read)
         self.assertEqual(self.partner.type, "contact")
         self.partner.sudo().write({"type": "private"})
         self.assertEqual(self.partner.type, "private")
         directory_id.invalidate_cache()
         self.assertTrue(directory_id.sudo().permission_read)
-        self.assertFalse(directory_id.sudo(self.admin_uid).permission_read)
-        self.assertFalse(directory_id.sudo(self.demo_uid).permission_read)
+        self.assertFalse(directory_id.sudo(self.user_admin.id).permission_read)
+        self.assertFalse(directory_id.sudo(self.user_demo.id).permission_read)
         self.assertFalse(directory_id.sudo(self.user.id).permission_read)
         # user can access self.partner
         self.user_demo.write(
@@ -92,4 +127,4 @@ class StorageAttachmentTestCase(DocumentsBaseCase):
                 ]
             }
         )
-        self.assertTrue(directory_id.sudo(self.demo_uid).permission_read)
+        self.assertTrue(directory_id.sudo(self.user_demo.id).permission_read)


### PR DESCRIPTION
Instead of relying on base users, create the ones we need for the test. This helps to avoid problems when other modules modify the groups for base users.

Missing changes from https://github.com/OCA/dms/pull/112

ping @victoralmau @Yajo 