### PR TITLE
[13.0][FIX] dms: Fix tests for environments that add other groups to base users

### DIFF
--- a/dms/tests/test_storage_attachment.py
+++ b/dms/tests/test_storage_attachment.py
@@ -1,4 +1,5 @@
 # Copyright 2021 Tecnativa - Víctor Martínez
+# Copyright 2021 Tecnativa - João Marques
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from .common import DocumentsBaseCase
@@ -17,6 +18,45 @@ class StorageAttachmentTestCase(DocumentsBaseCase):
                 "groups_id": [(6, 0, [self.env.ref("base.group_user").id])],
             }
         )
+        self.user_demo = self.env["res.users"].create(
+            {
+                "name": "User Base",
+                "login": "user_demo",
+                "groups_id": [
+                    (
+                        6,
+                        0,
+                        [
+                            self.env.ref("base.group_partner_manager").id,
+                            self.env.ref("base.group_user").id,
+                            self.env.ref("base.group_no_one").id,
+                            self.env.ref("dms.group_dms_user").id,
+                        ],
+                    )
+                ],
+            }
+        )
+        self.user_admin = self.env["res.users"].create(
+            {
+                "name": "User Admin",
+                "login": "user_admin",
+                "groups_id": [
+                    (
+                        6,
+                        0,
+                        [
+                            self.env.ref("base.group_erp_manager").id,
+                            self.env.ref("base.group_partner_manager").id,
+                            self.env.ref("base.group_user").id,
+                            self.env.ref("dms.group_dms_manager").id,
+                            self.env.ref("base.group_system").id,
+                            self.env.ref("base.group_no_one").id,
+                            self.env.ref("dms.group_dms_user").id,
+                        ],
+                    )
+                ],
+            }
+        )
 
     def _create_attachment(self, name, uid):
         self.create_attachment(
@@ -27,11 +67,11 @@ class StorageAttachmentTestCase(DocumentsBaseCase):
         ).with_user(uid)
 
     def test_storage_attachment(self):
-        self._create_attachment("demo.txt", self.admin_uid)
+        self._create_attachment("demo.txt", self.user_admin.id)
         self.assertTrue(
             self.storage.storage_file_ids.filtered(lambda x: x.name == "demo.txt")
         )
-        directory_id = self.directory.with_user(self.admin_uid).search(
+        directory_id = self.directory.with_user(self.user_admin.id).search(
             [
                 ("storage_id", "=", self.storage.id),
                 ("res_model", "=", self.model_res_partner.model),
@@ -42,7 +82,7 @@ class StorageAttachmentTestCase(DocumentsBaseCase):
         self.assertEqual(directory_id.file_ids[0].name, "demo.txt")
         file_01 = self.create_file(
             directory=directory_id, storage=directory_id.storage_id,
-        ).with_user(self.admin_uid)
+        ).with_user(self.user_admin.id)
         self.assertEqual(file_01.storage_id, self.storage)
         self.assertEqual(file_01.storage_id.save_type, "attachment")
         self.assertEqual(file_01.save_type, "database")
@@ -53,35 +93,28 @@ class StorageAttachmentTestCase(DocumentsBaseCase):
         self.assertFalse(directory_id.exists())
 
     def test_storage_attachment_directory_record_ref_access(self):
-        self._create_attachment("demo.txt", self.admin_uid)
-        directory_id = self.directory.with_user(self.admin_uid).search(
+        self._create_attachment("demo.txt", self.user_admin.id)
+        directory_id = self.directory.with_user(self.user_admin.id).search(
             [
                 ("storage_id", "=", self.storage.id),
                 ("res_model", "=", self.model_res_partner.model),
                 ("res_id", "=", self.partner.id),
             ]
         )
-        self.assertTrue(directory_id.with_user(self.admin_uid).permission_read)
-        self.assertTrue(directory_id.with_user(self.demo_uid).permission_read)
+        self.assertTrue(directory_id.with_user(self.user_admin.id).permission_read)
+        self.assertTrue(directory_id.with_user(self.user_demo.id).permission_read)
         self.assertTrue(directory_id.with_user(self.user.id).permission_read)
         self.assertEqual(self.partner.type, "contact")
         self.partner.sudo().write({"type": "private"})
         self.assertEqual(self.partner.type, "private")
         self.assertTrue(directory_id.sudo().permission_read)
-        if not self.browse_ref("base.user_admin").user_has_groups(
-            "base.group_private_addresses"
-        ):
-            directory_id.with_user(self.admin_uid).invalidate_cache()
-            self.assertFalse(directory_id.with_user(self.admin_uid).permission_read)
-        if not self.browse_ref("base.user_demo").user_has_groups(
-            "base.group_private_addresses"
-        ):
-            directory_id.with_user(self.demo_uid).invalidate_cache()
-            self.assertFalse(directory_id.with_user(self.demo_uid).permission_read)
-        directory_id.with_user(self.user).invalidate_cache()
+        directory_id.invalidate_cache()
+        self.assertFalse(directory_id.with_user(self.user_admin.id).permission_read)
+        directory_id.invalidate_cache()
+        self.assertFalse(directory_id.with_user(self.user_demo.id).permission_read)
         self.assertFalse(directory_id.with_user(self.user.id).permission_read)
         # user can access self.partner
-        self.browse_ref("base.user_demo").write(
+        self.user_demo.write(
             {
                 "groups_id": [
                     (
@@ -95,4 +128,4 @@ class StorageAttachmentTestCase(DocumentsBaseCase):
                 ]
             }
         )
-        self.assertTrue(directory_id.with_user(self.demo_uid).permission_read)
+        self.assertTrue(directory_id.with_user(self.user_demo.id).permission_read)


### PR DESCRIPTION
Instead of relying on base users, create the ones we need for the test. This helps to avoid problems when other modules modify the groups for base users.

FWP from 12.0: https://github.com/OCA/dms/pull/115

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa