### PR TITLE
[13.0][IMP+FIX] dms: Changes in file tree view + Fix file preview.

### DIFF
--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -370,7 +370,7 @@ class File(models.Model):
     @api.depends("content")
     def _compute_mimetype(self):
         for record in self:
-            record.res_mimetype = guess_mimetype(record.content or b"")
+            record.res_mimetype = guess_mimetype(base64.b64decode(record.content or ""))
 
     @api.depends("content_binary", "content_file", "attachment_id")
     def _compute_content(self):

--- a/dms/static/src/js/fields/path.js
+++ b/dms/static/src/js/fields/path.js
@@ -10,23 +10,6 @@ odoo.define("dms.fields_path", function(require) {
     var fields = require("web.basic_fields");
     var registry = require("web.field_registry");
 
-    var FieldPathNames = fields.FieldChar.extend({
-        init: function() {
-            this._super.apply(this, arguments);
-            this.max_width = this.nodeOptions.width || 500;
-        },
-        _renderReadonly: function() {
-            var show_value = this._formatValue(this.value);
-            var text_witdh = show_value.length;
-            if (text_witdh >= this.max_width) {
-                var ratio_start = (1 - this.max_width / text_witdh) * show_value.length;
-                show_value =
-                    ".." + show_value.substring(ratio_start, show_value.length);
-            }
-            this.$el.text(show_value);
-        },
-    });
-
     var FieldPathJson = fields.FieldText.extend({
         events: _.extend({}, fields.FieldText.prototype.events, {
             "click a": "_onNodeClicked",
@@ -90,11 +73,9 @@ odoo.define("dms.fields_path", function(require) {
         },
     });
 
-    registry.add("path_names", FieldPathNames);
     registry.add("path_json", FieldPathJson);
 
     return {
-        FieldPathNames: FieldPathNames,
         FieldPathJson: FieldPathJson,
     };
 });

--- a/dms/static/src/js/views/search_panel.js
+++ b/dms/static/src/js/views/search_panel.js
@@ -1,0 +1,45 @@
+/* Copyright 2021 Tecnativa - Víctor Martínez
+ * License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). */
+odoo.define("dms.SearchPanel", function(require) {
+    "use strict";
+
+    const core = require("web.core");
+    const SearchPanel = require("web.SearchPanel");
+    const _t = core._t;
+    SearchPanel.include({
+        _renderCategory: function() {
+            let res = this._super.apply(this, arguments);
+            if (this.model === "dms.directory") {
+                // Replace label on JS because QWeb has not enough context
+                const res_dom = $(res);
+                res_dom.find(".o_search_panel_label_title b").html(_t("Root"));
+                res = res_dom.html();
+            }
+            return res;
+        },
+        _getCategoryDomain: function() {
+            var domain = this._super.apply(this, arguments);
+            var field_name_need_check = false;
+            if (this.model === "dms.file") {
+                field_name_need_check = "directory_id";
+            } else if (this.model === "dms.directory") {
+                field_name_need_check = "parent_id";
+            }
+            if (field_name_need_check) {
+                domain.forEach(function(item, key) {
+                    if (item[0] === field_name_need_check && item[1] === "child_of") {
+                        domain[key] = [item[0], "=", item[2]];
+                    }
+                });
+            }
+            if (
+                domain.length === 0 &&
+                field_name_need_check &&
+                this.model === "dms.directory"
+            ) {
+                domain.push([field_name_need_check, "=", false]);
+            }
+            return domain;
+        },
+    });
+});

--- a/dms/template/assets.xml
+++ b/dms/template/assets.xml
@@ -39,6 +39,10 @@
                 type="text/javascript"
                 src="/dms/static/src/js/views/file_kanban_view.js"
             />
+            <script
+                type="text/javascript"
+                src="/dms/static/src/js/views/search_panel.js"
+            />
         </xpath>
     </template>
 </odoo>

--- a/dms/tests/test_file.py
+++ b/dms/tests/test_file.py
@@ -78,3 +78,9 @@ class FileFilestoreTestCase(FileTestCase):
         self.assertNotEqual(oid, lobject_file.with_context({"oid": True}).content_file)
         self.assertTrue(lobject_file.export_data(["content"]))
         lobject_file.unlink()
+
+    def test_content_file_res_mimetype(self):
+        file_svg = self.env.ref("dms.file_05_demo")
+        self.assertEqual(file_svg.res_mimetype, "image/svg+xml")
+        file_logo = self.env.ref("dms.file_02_demo")
+        self.assertEqual(file_logo.res_mimetype, "image/jpeg")

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -228,20 +228,26 @@
                             <div class="oe_kanban_content">
                                 <div class="o_kanban_image">
                                     <div class="o_kanban_image_wrapper">
-                                        <t
-                                            t-if="record.custom_thumbnail_small.raw_value"
+                                        <a
+                                            class="o_kanban_dms_file_preview"
+                                            t-att-data-id="widget.db_id"
                                         >
-                                            <img
-                                                t-att-src="kanban_image('dms.file', 'custom_thumbnail_small', record.id.raw_value)"
-                                                alt="Custom thumbnail"
-                                            />
-                                        </t>
-                                        <t t-else="">
-                                            <img
-                                                t-att-src="record.icon_url.raw_value"
-                                                alt="Icon"
-                                            />
-                                        </t>
+                                            <t
+                                                t-if="record.custom_thumbnail_small.raw_value"
+                                            >
+                                                <img
+                                                    t-att-src="kanban_image('dms.file', 'custom_thumbnail_small', record.id.raw_value)"
+                                                    t-att-class="o_kanban_dms_file_preview"
+                                                    alt="Custom thumbnail"
+                                                />
+                                            </t>
+                                            <t t-else="">
+                                                <img
+                                                    t-att-src="record.icon_url.raw_value"
+                                                    alt="Icon"
+                                                />
+                                            </t>
+                                        </a>
                                     </div>
                                 </div>
                                 <div class="o_kanban_details">
@@ -249,10 +255,6 @@
                                         <div
                                             class="o_kanban_record_title o_text_overflow"
                                         >
-                                            <a
-                                                class="o_kanban_dms_file_preview fa fa-search"
-                                                t-att-data-id="widget.db_id"
-                                            />
                                             <field name="name" />
                                         </div>
                                         <div class="o_kanban_record_body">

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -304,15 +304,20 @@
                 js_class="file_list"
                 decoration-warning="not active"
                 decoration-muted="(is_locked and not is_lock_editor)"
+                multi_edit="1"
             >
                 <field name="active" invisible="1" />
                 <field name="is_locked" invisible="1" />
                 <field name="is_lock_editor" invisible="1" />
                 <field name="name" />
-                <field name="write_date" />
-                <field name="size" />
-                <field name="res_mimetype" />
-                <field name="path_names" widget="path_names" string="Path" />
+                <field name="write_date" readonly="1" />
+                <field name="size" readonly="1" />
+                <field name="res_mimetype" readonly="1" />
+                <field
+                    name="tag_ids"
+                    widget="many2many_tags"
+                    options="{'color_field': 'color', 'no_create_edit': True}"
+                />
             </tree>
         </field>
     </record>


### PR DESCRIPTION
[IMP] Changes in file tree view (It's necessary to change in 14.0)
[FIX] File preview.
[IMP ]Show in directory kanban view only root directories (Change **All** text to **Root**) + Change to searchpanel _directory_id_ (in files) or _parent_id_ (in directories) to filter equal and not _child_of_ (It's related to https://github.com/OCA/dms/issues/40 )

Locked by:
- [x] https://github.com/OCA/social/pull/744

Please @pedrobaeza and @Yajo can you review it?

@Tecnativa TT30992