### PR TITLE
Explicit Access Group instructions

### DIFF
--- a/dms/readme/CONFIGURE.rst
+++ b/dms/readme/CONFIGURE.rst
@@ -4,9 +4,14 @@ To configure this module, you need to:
 #. Create a new document storage. You can choose between two options on `Save Type`:
     * `Database`: Store the files on the database as a field
     * `Attachment`: Store the files as attachments
+#. Next create an administrative access group. Go to *Configuration -> Access Groups*.
+    * Create a new group, name it appropriately, and turn on all three permissions (Create, Write and Unlink - Read is implied and always enabled).
+    * Add any other top-level administrative users to the group if needed (your user should already be there).
+    * You can create other groups in here later for fine grained access control.
 #. Afterwards go to *Documents -> Directories*.
 #. Create a new directory, mark it as root and select the previously created setting.
-#. On the Directory you can also define the access groups that will be able to:
+    * Select the *Groups* tab and add your administrative group created above.
+#. On the Directory you can also add other access groups (created above) that will be able to:
     * read
     * create
     * write


### PR DESCRIPTION
Add explicit access group creation and usage instructions in the brief getting started instructions.