### PR TITLE
[IMP] dms: Set the drop target to the kanban view, excluding the search panel

### DIFF
--- a/dms/static/src/js/views/many_drop_target.js
+++ b/dms/static/src/js/views/many_drop_target.js
@@ -19,7 +19,7 @@ odoo.define("dms.DragDrop", function(require) {
                 this._searchPanel ? this._searchPanel.getDomain() : []
             );
         },
-
+        _drop_zone_selector: ".o_kanban_view",
         /**
          * @override
          */


### PR DESCRIPTION
Necessary to change this because of https://github.com/OCA/web/pull/2065

This is the current behaviour:
![image](https://user-images.githubusercontent.com/28590170/139404887-560d080b-8e8a-4c10-8bbf-de64fd64e224.png)

When merged the web PR without changes:
![image](https://user-images.githubusercontent.com/28590170/139405030-57676394-70eb-4825-a3a5-633fbb3822e0.png)

Proposed (works with and without the PR):
![image](https://user-images.githubusercontent.com/28590170/139404736-9b0047e1-cb08-4b82-9a0a-aa861834d3ea.png)

@Tardo 