### PR TITLE
[13.0][FIX] dms: Define the file extension correctly (even if there is no extension in the file name).

### DIFF
--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -373,10 +373,12 @@ class File(models.Model):
                 }
             )
 
-    @api.depends("name")
+    @api.depends("name", "res_mimetype", "content")
     def _compute_extension(self):
         for record in self:
-            record.extension = file.guess_extension(record.name)
+            record.extension = file.guess_extension(
+                record.name, record.res_mimetype, record.content
+            )
 
     @api.depends("content")
     def _compute_mimetype(self):

--- a/dms/tests/test_file.py
+++ b/dms/tests/test_file.py
@@ -96,3 +96,11 @@ class FileFilestoreTestCase(FileTestCase):
             self.skipTest("Without python-magic library installed")
         file_video = self.env.ref("dms.file_10_demo")
         self.assertEqual(file_video.res_mimetype, "video/mp4")
+
+    def test_content_file_extension(self):
+        file_pdf = self.env.ref("dms.file_27_demo")
+        self.assertEqual(file_pdf.extension, "pdf")
+        file_pdf.name = "Document_05"
+        self.assertEqual(file_pdf.extension, "pdf")
+        file_pdf.name = "Document_05.pdf"
+        self.assertEqual(file_pdf.extension, "pdf")

--- a/dms/tools/file.py
+++ b/dms/tools/file.py
@@ -43,7 +43,7 @@ def unique_name(name, names, escape_suffix=False):
 
 def guess_extension(filename=None, mimetype=None, binary=None):
     extension = filename and os.path.splitext(filename)[1][1:].strip().lower()
-    if not extension and mimetype:
+    if not extension and mimetype and mimetype != "application/x-empty":
         extension = mimetypes.guess_extension(mimetype)[1:].strip().lower()
     if not extension and binary:
         mimetype = guess_mimetype(binary, default="")


### PR DESCRIPTION
Define the file extension correctly (even if there is no extension in the file name). 
Related to https://github.com/OCA/dms/issues/125.

Please @joao-p-marques and @Yajo can you review it?

@Tecnativa