### PR TITLE
[13.0][FIX] dms: Show the total of files (of all subdirectories) in the form view of the directories

### DIFF
--- a/dms/views/directory.xml
+++ b/dms/views/directory.xml
@@ -504,7 +504,7 @@
                                         name="count_directories"
                                         string="Directories"
                                     />
-                                    <field name="count_files" string="Files" />
+                                    <field name="count_total_files" string="Files" />
                                     <field name="size" />
                                 </tree>
                             </field>


### PR DESCRIPTION
Show the total of files (of all subdirectories) in the form view of the directories.
Related to https://github.com/OCA/dms/issues/123

![dms_folder](https://user-images.githubusercontent.com/4117568/140480865-a88c826e-c7c2-4870-a453-b40e7124a411.png)

Please @joao-p-marques and @Yajo can you review it?

@Tecnativa