### PR TITLE
[13.0][FIX] dms: Change size field type from integer to float to prevent 2147483647 limit from postgresql.

### DIFF
--- a/dms/models/directory.py
+++ b/dms/models/directory.py
@@ -183,7 +183,7 @@ class DmsDirectory(models.Model):
         compute="_compute_count_total_elements", string="Total Elements"
     )
 
-    size = fields.Integer(compute="_compute_size", string="Size")
+    size = fields.Float(compute="_compute_size", string="Size")
 
     inherit_group_ids = fields.Boolean(string="Inherit Groups", default=True)
 

--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -103,7 +103,7 @@ class File(models.Model):
         compute="_compute_mimetype", string="Type", readonly=True, store=True
     )
 
-    size = fields.Integer(string="Size", readonly=True)
+    size = fields.Float(string="Size", readonly=True)
 
     checksum = fields.Char(string="Checksum/SHA1", readonly=True, size=40, index=True)
 

--- a/dms/views/directory.xml
+++ b/dms/views/directory.xml
@@ -451,7 +451,7 @@
                     </group>
                     <group name="data">
                         <group>
-                            <field name="size" />
+                            <field name="size" widget="integer" />
                             <field name="count_elements" string="Elements" />
                         </group>
                         <group>
@@ -505,7 +505,7 @@
                                         string="Directories"
                                     />
                                     <field name="count_total_files" string="Files" />
-                                    <field name="size" />
+                                    <field name="size" widget="integer" />
                                 </tree>
                             </field>
                         </page>

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -301,7 +301,7 @@
                 <field name="is_lock_editor" invisible="1" />
                 <field name="name" />
                 <field name="write_date" readonly="1" />
-                <field name="size" readonly="1" />
+                <field name="size" widget="integer" readonly="1" />
                 <field name="res_mimetype" readonly="1" />
                 <field
                     name="tag_ids"


### PR DESCRIPTION
Change `size` field type from integer to float to prevent 2147483647 limit from postgresql.

Please @pedrobaeza and @chienandalu can you review it?

It's need to apply too to 14.0

@Tecnativa TT33935