### PR TITLE
[13.0][FIX] dms: Prevent CacheMis error from count_total_files in some NewId use cases.

### DIFF
--- a/dms/models/directory.py
+++ b/dms/models/directory.py
@@ -410,15 +410,19 @@ class DmsDirectory(models.Model):
 
     def _compute_count_total_directories(self):
         for record in self:
-            count = self.search_count([("id", "child_of", record.id)])
-            count = count - 1 if count > 0 else 0
-            record.count_total_directories = count
+            count = (
+                self.search_count([("id", "child_of", record.id)]) if record.id else 0
+            )
+            record.count_total_directories = count - 1 if count > 0 else 0
 
     def _compute_count_total_files(self):
         model = self.env["dms.file"]
         for record in self:
-            record.count_total_files = model.search_count(
-                [("directory_id", "child_of", record.id)]
+            # Prevent error in some NewId cases
+            record.count_total_files = (
+                model.search_count([("directory_id", "child_of", record.id)])
+                if record.id
+                else 0
             )
 
     def _compute_count_total_elements(self):


### PR DESCRIPTION
Prevent CacheMis error from `count_total_files` in some NewId use cases.

Related to: https://github.com/OCA/dms/issues/137

Please @pedrobaeza and @chienandalu can you review it?

It's need to apply too to 14.0

@Tecnativa TT34095