### PR TITLE
[14.0][FIX] dms: Replace the content field with size in the form view of the directory

### DIFF
--- a/dms/views/directory.xml
+++ b/dms/views/directory.xml
@@ -523,7 +523,7 @@
                                 <tree string="Files" limit="10">
                                     <field name="name" />
                                     <field name="mimetype" />
-                                    <field name="content" />
+                                    <field name="size" widget="integer" />
                                     <field name="write_date" readonly="1" />
                                 </tree>
                             </field>

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -549,7 +549,7 @@
                 <field name="is_lock_editor" invisible="1" />
                 <field name="name" />
                 <field name="write_date" />
-                <field name="content" />
+                <field name="size" widget="integer" />
                 <field name="mimetype" />
                 <field name="storage_id" />
                 <field name="migration" />


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/dms/pull/160

Replace the content field with size in the form view of the directory (file_ids field) because it is totally wrong to try to show that field.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT34353