### PR TITLE
[14.0][FIX] dms: The internal user group is added as an inheritance to the new group.

### DIFF
--- a/dms/security/security.xml
+++ b/dms/security/security.xml
@@ -14,6 +14,7 @@
     <record id="group_dms_user" model="res.groups">
         <field name="name">User</field>
         <field name="category_id" ref="category_dms_security" />
+        <field name="implied_ids" eval="[(4, ref('base.group_user'))]" />
     </record>
     <record id="group_dms_manager" model="res.groups">
         <field name="name">Manager</field>


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/dms/pull/165

The internal user group is added as an inheritance to the new group.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa