### PR TITLE
Revert "[14.0][FIX] dms: Prevent 200 records limit in search panel."

### DIFF
--- a/dms/models/abstract_dms_mixin.py
+++ b/dms/models/abstract_dms_mixin.py
@@ -1,12 +1,9 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-import odoo
-from odoo import api, fields
-
-from odoo.addons.web.models import models
+from odoo import fields, models
 
 
-class AbstractDmsMixin(odoo.models.AbstractModel):
+class AbstractDmsMixin(models.AbstractModel):
     _name = "abstract.dms.mixin"
     _description = "Abstract Dms Mixin"
 
@@ -36,13 +33,3 @@ class AbstractDmsMixin(odoo.models.AbstractModel):
         context="{'dms_category_show_path': True}",
         string="Category",
     )
-
-    @api.model
-    def search_panel_select_range(self, field_name):
-        """We need to override function to prevent 200 records limit in search panel"""
-        old_value = models.SEARCH_PANEL_LIMIT
-        models.SEARCH_PANEL_LIMIT = False
-        _self = self.with_context(directory_short_name=True)
-        res = super(AbstractDmsMixin, _self).search_panel_select_range(field_name)
-        models.SEARCH_PANEL_LIMIT = old_value
-        return res

--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -289,14 +289,21 @@ class File(models.Model):
         operator, directory_id = self._search_panel_directory(**kwargs)
         if directory_id and field_name == "directory_id":
             domain = [("parent_id", operator, directory_id)]
-            values = self.env["dms.directory"].search_read(
-                domain, ["display_name", "parent_id"]
+            values = (
+                self.env["dms.directory"]
+                .with_context(directory_short_name=True)
+                .search_read(domain, ["display_name", "parent_id"])
             )
             return {
                 "parent_field": "parent_id",
                 "values": values if len(values) > 1 else [],
             }
-        return super().search_panel_select_range(field_name, **kwargs)
+        context = {}
+        if field_name == "directory_id":
+            context["directory_short_name"] = True
+        return super(File, self.with_context(**context)).search_panel_select_range(
+            field_name, **kwargs
+        )
 
     @api.model
     def search_panel_select_multi_range(self, field_name, **kwargs):

--- a/dms/static/src/xml/views.xml
+++ b/dms/static/src/xml/views.xml
@@ -69,9 +69,4 @@
             />
         </t>
     </t>
-    <t t-extend="SearchPanel.CategoryValues">
-        <t t-jquery=".o_search_panel_label" t-operation="attributes">
-            <attribute name="t-att-title">value.display_name</attribute>
-        </t>
-    </t>
 </templates>

--- a/dms/tests/test_directory.py
+++ b/dms/tests/test_directory.py
@@ -1,11 +1,9 @@
 # Copyright 2017-2019 MuK IT GmbH.
 # Copyright 2020 Creu Blanca
-# Copyright 2021-2022 Tecnativa - Víctor Martínez
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo.exceptions import UserError
-
-from odoo.addons.web.models.models import SEARCH_PANEL_LIMIT
 
 from .common import DocumentsBaseCase, multi_users
 
@@ -154,19 +152,3 @@ class DirectoryTestCase(DocumentsBaseCase):
         self.assertTrue(self.directory.search_panel_select_multi_range("parent_id"))
         self.assertTrue(self.directory.search_panel_select_multi_range("category_id"))
         self.assertTrue(self.directory.search_panel_select_multi_range("tag_ids"))
-
-    def test_directory_search_panel_limit(self):
-        self.directory_sub_demo_01 = self.browse_ref("dms.directory_04_demo")
-        limit = SEARCH_PANEL_LIMIT + 20
-        for number in range(limit):
-            self.directory.sudo().create(
-                {
-                    "name": "Test Directory %s" % str(number),
-                    "parent_id": self.directory_sub_demo_01.parent_id.id,
-                    "storage_id": self.directory_sub_demo_01.storage_id.id,
-                }
-            )
-        res = self.directory.search_panel_select_range("parent_id")
-        self.assertGreaterEqual(len(res["values"]), limit)
-        res = self.file.search_panel_select_range("directory_id")
-        self.assertGreaterEqual(len(res["values"]), limit)


### PR DESCRIPTION
Reverts OCA/dms#180

It is failing, as you can see on the travis action. I think it is probably no longer needed