### PR TITLE
[13.0][IMP] dms: Don't restrict model_id as it can be False

### DIFF
--- a/dms/views/directory.xml
+++ b/dms/views/directory.xml
@@ -478,7 +478,7 @@
                         <field name="allowed_model_ids" invisible="True" />
                         <field
                             name="model_id"
-                            attrs="{'invisible': [('storage_id_save_type', '!=', 'attachment')], 'readonly': [('count_total_files', '>', 0)], 'required': [('storage_id_save_type','=','attachment')]}"
+                            attrs="{'invisible': [('storage_id_save_type', '!=', 'attachment')], 'readonly': [('count_total_files', '>', 0)]}"
                         />
                         <field name="res_model" invisible="1" force_save="1" />
                         <field


### PR DESCRIPTION
As model_id can be False (directory can be not linked to any model):

https://github.com/OCA/dms/blob/13.0/dms/models/directory.py#L307

This had been introduced there:

https://github.com/OCA/dms/commit/7cc0d07dcd04e3c7dc245cbd0d4a6b4795b90b8e

@victoralmau 