### PR TITLE
[13.0][FIX] dms: Apply sudo() when downloading the files (portal users do not have access to ir.attachment for example).

### DIFF
--- a/dms/controllers/portal.py
+++ b/dms/controllers/portal.py
@@ -182,7 +182,7 @@ class CustomerPortal(CustomerPortal):
             else:
                 return request.redirect("/my")
 
-        dms_file_sudo = res
+        dms_file_sudo = res.sudo()
         filecontent = base64.b64decode(dms_file_sudo.content)
         content_type = ["Content-Type", "application/octet-stream"]
         disposition_content = [


### PR DESCRIPTION
Apply `sudo()` when downloading the files (portal users do not have access to ir.attachment for example).

Please @chienandalu and @pedrobaeza can you review it?

@Tecnativa TT36723