### PR TITLE
[FIX] dms: do_warn method no longer available in v15

### DIFF
--- a/dms/static/src/js/views/many_drop_target.js
+++ b/dms/static/src/js/views/many_drop_target.js
@@ -47,7 +47,10 @@ odoo.define("dms.DragDrop", function (require) {
             }
             console.log(ctx);
             if (typeof ctx.default_directory_id === "undefined") {
-                return this.do_warn(_t("You must select a directory first"));
+                return this.displayNotification({
+                    message: _t("You must select a directory first"),
+                    type: "danger",
+                });
             }
             return this._rpc({
                 model: res_model,


### PR DESCRIPTION
When file is dragged&dropped into the DMS, it should show warning if no directory is selected. Instead of warning, an error is thrown, because of do_warn, which was not replace with displayNotification when migrating to v15.