### PR TITLE
[12.0][IMP] DMS: Change Access Rights for dms.access.group

### DIFF
--- a/dms/security/ir.model.access.csv
+++ b/dms/security/ir.model.access.csv
@@ -19,4 +19,5 @@ access_dms_file_user,dms_file_user,model_dms_file,group_dms_user,1,1,1,1
 
 access_dms_access_group_public,access_dms_access_group_public,model_dms_access_group,base.group_public,1,0,0,0
 access_dms_access_group_portal,access_dms_access_group_portal,model_dms_access_group,base.group_portal,1,0,0,0
-access_security_access_groups_user,access_security_access_groups_user,model_dms_access_group,base.group_user,1,1,1,1
+access_security_access_groups_user,access_security_access_groups_user,model_dms_access_group,base.group_user,1,0,0,0
+access_security_access_groups_dms_user,access_security_access_groups_dms_user,model_dms_access_group,group_dms_user,1,1,1,1

--- a/dms/security/security.xml
+++ b/dms/security/security.xml
@@ -11,8 +11,13 @@
     <record id="category_dms_security" model="ir.module.category">
         <field name="name">Documents</field>
     </record>
+    <record id="group_dms_readonly_user" model="res.groups">
+        <field name="name">Readonly User</field>
+        <field name="category_id" ref="category_dms_security" />
+    </record>
     <record id="group_dms_user" model="res.groups">
         <field name="name">User</field>
+        <field name="implied_ids" eval="[(4, ref('group_dms_readonly_user'))]" />
         <field name="category_id" ref="category_dms_security" />
     </record>
     <record id="group_dms_manager" model="res.groups">
@@ -61,20 +66,20 @@
             name="domain_force"
         >['|', ('locked_by', '=', False), ('locked_by', '=', user.id)]</field>
     </record>
-    <record id="rule_security_groups_user" model="ir.rule">
-        <field name="name">User can only edit and delete their own groups.</field>
+    <record id="rule_security_groups_dms_user" model="ir.rule">
+        <field name="name">DMS users can only edit and delete their own groups.</field>
         <field name="model_id" ref="model_dms_access_group" />
-        <field name="groups" eval="[(4, ref('base.group_user'))]" />
+        <field name="groups" eval="[(4, ref('group_dms_user'))]" />
         <field name="perm_read" eval="0" />
         <field name="perm_create" eval="0" />
         <field name="perm_write" eval="1" />
         <field name="perm_unlink" eval="1" />
         <field name="domain_force">[('create_uid','=',user.id)]</field>
     </record>
-    <record id="rule_security_groups_manager" model="ir.rule">
-        <field name="name">Admins can edit and delete all groups.</field>
+    <record id="rule_security_groups_dms_manager" model="ir.rule">
+        <field name="name">DMS Managers can edit and delete all groups.</field>
         <field name="model_id" ref="model_dms_access_group" />
-        <field name="groups" eval="[(4, ref('base.group_erp_manager'))]" />
+        <field name="groups" eval="[(4, ref('group_dms_manager'))]" />
         <field name="perm_read" eval="0" />
         <field name="perm_create" eval="0" />
         <field name="perm_write" eval="1" />

--- a/dms/tests/__init__.py
+++ b/dms/tests/__init__.py
@@ -1,4 +1,5 @@
 from . import common
+from . import test_access_group
 from . import test_storage_attachment
 from . import test_storage_database
 from . import test_storage

--- a/dms/tests/common.py
+++ b/dms/tests/common.py
@@ -36,7 +36,7 @@ def multi_users(users=False, reset=True, raise_exception=True, callback=False):
                         self.uid = self.ref(user[0])
                     else:
                         self.uid = user[0]
-                    if hasattr(self, callback):
+                    if callback and hasattr(self, callback):
                         callb = getattr(self, callback)
                         if callable(callb):
                             callb()

--- a/dms/tests/test_access_group.py
+++ b/dms/tests/test_access_group.py
@@ -1,0 +1,100 @@
+from odoo.tests import SavepointCase
+
+from .common import multi_users
+
+
+class AccessGroupTestCase(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.DmsAccessGroup = cls.env["dms.access.group"]
+        cls.base_user = cls.env["res.users"].create(
+            {
+                "name": "Base User",
+                "login": "base",
+                "groups_id": [(6, 0, [cls.env.ref("base.group_user").id])],
+            }
+        )
+        cls.dms_user = cls.env["res.users"].create(
+            {
+                "name": "DMS User",
+                "login": "dms_user",
+                "groups_id": [(6, 0, [cls.env.ref("dms.group_dms_user").id])],
+            }
+        )
+        cls.dms_manager = cls.env["res.users"].create(
+            {
+                "name": "DMS Manager",
+                "login": "dms_manager",
+                "groups_id": [(6, 0, [cls.env.ref("dms.group_dms_manager").id])],
+            }
+        )
+
+        cls.access_group_base_user = cls.DmsAccessGroup.create(
+            {"name": "Base Group", "create_uid": cls.base_user.id}
+        )
+        cls.access_group_dms_user = cls.DmsAccessGroup.create(
+            {"name": "DMS User Group", "create_uid": cls.dms_user.id}
+        )
+        cls.access_group_dms_manager = cls.DmsAccessGroup.create(
+            {"name": "DMS Manager Group", "create_uid": cls.dms_manager.id}
+        )
+        cls.test_access_groups = (
+            cls.access_group_base_user
+            + cls.access_group_dms_user
+            + cls.access_group_dms_manager
+        )
+
+    @multi_users(
+        lambda self: (
+            (self.base_user.id, True),
+            (self.dms_user.id, True),
+            (self.dms_manager.id, True),
+        ),
+    )
+    def test_can_read_all_groups(self):
+        access_groups = (
+            self.env["dms.access.group"]
+            .sudo(self.uid)
+            .search([("id", "in", self.test_access_groups.ids)])
+        )
+        self.assertEqual(len(self.test_access_groups), len(access_groups))
+
+    @multi_users(
+        lambda self: (
+            (self.base_user.id, False),
+            (self.dms_user.id, True),
+            (self.dms_manager.id, True),
+        ),
+    )
+    def test_can_create_groups(self):
+        self.DmsAccessGroup.sudo(self.uid).create({"name": "test"})
+
+    @multi_users(
+        lambda self: (
+            (self.base_user.id, False),
+            (self.dms_user.id, True),
+            (self.dms_manager.id, True),
+        ),
+    )
+    def test_write_unlink_own_group(self):
+        access_group = self.test_access_groups.filtered(
+            lambda x: x.create_uid.id == self.uid
+        )
+        access_group.sudo(self.uid).write({"name": "New name"})
+        access_group.sudo(self.uid).unlink()
+
+    @multi_users(
+        lambda self: (
+            (self.base_user.id, False),
+            (self.dms_user.id, False),
+            (self.dms_manager.id, True),
+        ),
+    )
+    def write_unlink_other_group(self):
+        access_groups = self.test_access_groups.filtered(
+            lambda x: x.create_uid.id != self.uid
+        )
+        for group in access_groups:
+            group.sudo(self.uid).write({"name": "New name"})
+            group.sudo(self.uid).unlink()


### PR DESCRIPTION
Proposing a change in the permissions for DMS Access Groups:

- Not every user can create new access groups, but only dms_users.
- DMS managers (not admin users) can manage every access group
- Add tests

After this change:
- the base user has read only access
- the group_dms_user can create, and can write and unlink their own groups
- the group_dms_manager can do everything on every group.