### PR TITLE
[15.0][IMP+FIX] dms: Searchpanel changes.

### DIFF
--- a/dms/models/category.py
+++ b/dms/models/category.py
@@ -117,6 +117,14 @@ class Category(models.Model):
         for record in self:
             record.count_files = len(record.file_ids)
 
+    def name_get(self):
+        if not self.env.context.get("category_short_name", False):
+            return super().name_get()
+        vals = []
+        for record in self:
+            vals.append(tuple([record.id, record.name]))
+        return vals
+
     # ----------------------------------------------------------
     # Create
     # ----------------------------------------------------------

--- a/dms/models/directory.py
+++ b/dms/models/directory.py
@@ -331,6 +331,25 @@ class DmsDirectory(models.Model):
         self.recompute()
 
     # ----------------------------------------------------------
+    # SearchPanel
+    # ----------------------------------------------------------
+
+    @api.model
+    def search_panel_select_range(self, field_name, **kwargs):
+        context = {}
+        if field_name == "parent_id":
+            context["directory_short_name"] = True
+        return super(
+            DmsDirectory, self.with_context(**context)
+        ).search_panel_select_range(field_name, **kwargs)
+
+    @api.model
+    def search_panel_select_multi_range(self, field_name, **kwargs):
+        return super(
+            DmsDirectory, self.with_context(category_short_name=True)
+        ).search_panel_select_multi_range(field_name, **kwargs)
+
+    # ----------------------------------------------------------
     # Actions
     # ----------------------------------------------------------
 

--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -300,6 +300,8 @@ class File(models.Model):
         context = {}
         if field_name == "directory_id":
             context["directory_short_name"] = True
+        elif field_name == "category_id":
+            context["category_short_name"] = True
         return super(File, self.with_context(**context)).search_panel_select_range(
             field_name, **kwargs
         )

--- a/dms/views/directory.xml
+++ b/dms/views/directory.xml
@@ -164,15 +164,22 @@
                     <field
                         name="parent_id"
                         icon="fa-folder"
-                        context="{'directory_short_name': True}"
+                        limit="0"
                         enable_counters="1"
                     />
-                    <field name="category_id" select="multi" icon="fa-users" />
+                    <field
+                        name="category_id"
+                        select="multi"
+                        groupby="parent_id"
+                        icon="fa-users"
+                        limit="0"
+                    />
                     <field
                         name="tag_ids"
                         select="multi"
                         icon="fa-tag"
                         groupby="category_id"
+                        limit="0"
                         enable_counters="1"
                     />
                 </searchpanel>

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -71,10 +71,15 @@
                     <field
                         name="directory_id"
                         icon="fa-folder"
-                        context="{'directory_short_name': True}"
+                        limit="0"
                         enable_counters="1"
                     />
-                    <field name="category_id" icon="fa-users" enable_counters="1" />
+                    <field
+                        name="category_id"
+                        icon="fa-users"
+                        limit="0"
+                        enable_counters="1"
+                    />
                 </searchpanel>
             </search>
         </field>
@@ -534,8 +539,18 @@
                     />
                 </group>
                 <searchpanel>
-                    <field name="directory_id" icon="fa-folder" enable_counters="1" />
-                    <field name="category_id" icon="fa-users" enable_counters="1" />
+                    <field
+                        name="directory_id"
+                        icon="fa-folder"
+                        limit="0"
+                        enable_counters="1"
+                    />
+                    <field
+                        name="category_id"
+                        icon="fa-users"
+                        limit="0"
+                        enable_counters="1"
+                    />
                 </searchpanel>
             </search>
         </field>


### PR DESCRIPTION
Searchpanel changes:
- [x] Set `limit=0` to prevent js default limit https://github.com/odoo/odoo/blob/15.0/addons/web/static/src/search/search_arch_parser.js#L10 (https://github.com/OCA/server-auth/pull/413#issuecomment-1235104735)
- [x] ]Removes the context of fields (not used in .js calls).
- [x] Display the short name of the category (no hierarchy) in Directory menu.

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa