### PR TITLE
[14.0][OU-FIX] dms: Don't crash when migrating from 13.0.8.0.0

### DIFF
--- a/dms/migrations/14.0.4.0.0/post-migration.py
+++ b/dms/migrations/14.0.4.0.0/post-migration.py
@@ -6,6 +6,8 @@ from openupgradelib import openupgrade, openupgrade_90
 def convert_binary_fields_to_attachment(env):
     """Convert old user-provided thumbnails to attachments."""
     column = openupgrade.get_legacy_name("custom_thumbnail")
+    if not openupgrade.column_exists(env.cr, "dms_file", column):
+        return
     spec = {
         "dms.file": [("image_1920", column)],
         "dms.directory": [("image_1920", column)],

--- a/dms/migrations/14.0.4.0.0/pre-migration.py
+++ b/dms/migrations/14.0.4.0.0/pre-migration.py
@@ -11,4 +11,5 @@ column_renames = {
 
 @openupgrade.migrate()
 def migrate(env, version):
-    openupgrade.rename_columns(env.cr, column_renames)
+    if openupgrade.column_exists(env.cr, "dms_file", "custom_thumbnail"):
+        openupgrade.rename_columns(env.cr, column_renames)


### PR DESCRIPTION
When coming from 13.0 latest version, the conversion of the thumbnails has already been done, so this is failing saying:

psycopg2.errors.UndefinedColumn: column "custom_thumbnail" does not exist

@Tecnativa