### PR TITLE
[15.0][IMP+FIX] dms: Changes in file tree view + Fix file preview.

### DIFF
--- a/dms/__manifest__.py
+++ b/dms/__manifest__.py
@@ -38,6 +38,7 @@
             "dms/static/src/scss/directory_kanban.scss",
             "dms/static/src/js/fields/path.js",
             "dms/static/src/js/views/many_drop_target.js",
+            "dms/static/src/js/views/search_panel.esm.js",
             "dms/static/src/js/views/file_list_controller.js",
             "dms/static/src/js/views/file_list_view.js",
             "dms/static/src/js/views/file_kanban_controller.js",

--- a/dms/models/abstract_dms_mixin.py
+++ b/dms/models/abstract_dms_mixin.py
@@ -1,6 +1,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class AbstractDmsMixin(models.AbstractModel):
@@ -33,3 +33,11 @@ class AbstractDmsMixin(models.AbstractModel):
         context="{'dms_category_show_path': True}",
         string="Category",
     )
+
+    @api.model
+    def search_panel_select_range(self, field_name, **kwargs):
+        """Add context to display short folder name."""
+        _self = self.with_context(directory_short_name=True)
+        return super(AbstractDmsMixin, _self).search_panel_select_range(
+            field_name, **kwargs
+        )

--- a/dms/static/src/js/fields/path.js
+++ b/dms/static/src/js/fields/path.js
@@ -10,23 +10,6 @@ odoo.define("dms.fields_path", function (require) {
     var fields = require("web.basic_fields");
     var registry = require("web.field_registry");
 
-    var FieldPathNames = fields.FieldChar.extend({
-        init: function () {
-            this._super.apply(this, arguments);
-            this.max_width = this.nodeOptions.width || 500;
-        },
-        _renderReadonly: function () {
-            var show_value = this._formatValue(this.value);
-            var text_witdh = show_value.length;
-            if (text_witdh >= this.max_width) {
-                var ratio_start = (1 - this.max_width / text_witdh) * show_value.length;
-                show_value =
-                    ".." + show_value.substring(ratio_start, show_value.length);
-            }
-            this.$el.text(show_value);
-        },
-    });
-
     var FieldPathJson = fields.FieldText.extend({
         events: _.extend({}, fields.FieldText.prototype.events, {
             "click a": "_onNodeClicked",
@@ -90,11 +73,9 @@ odoo.define("dms.fields_path", function (require) {
         },
     });
 
-    registry.add("path_names", FieldPathNames);
     registry.add("path_json", FieldPathJson);
 
     return {
-        FieldPathNames: FieldPathNames,
         FieldPathJson: FieldPathJson,
     };
 });

--- a/dms/static/src/js/views/search_panel.esm.js
+++ b/dms/static/src/js/views/search_panel.esm.js
@@ -1,0 +1,42 @@
+/** @odoo-module **/
+/* Copyright 2021-2022 Tecnativa - Víctor Martínez
+ * License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). */
+
+import SearchPanelModelExtension from "@web/legacy/js/views/search_panel_model_extension";
+import {patch} from "web.utils";
+
+patch(SearchPanelModelExtension.prototype, "dms.SearchPanel", {
+    _createCategoryTree(sectionId) {
+        this._super.apply(this, arguments);
+        if (this.config.modelName === "dms.directory") {
+            const category = this.state.sections.get(sectionId);
+            category.values.get(false).display_name = this.env._t("Root");
+        }
+    },
+    _getCategoryDomain(excludedCategoryId) {
+        const domain = this._super.apply(this, arguments);
+        for (const category of this.categories) {
+            var attrs_item = this.config.archNodes[category.index].attrs;
+            if (category.id === excludedCategoryId) {
+                continue;
+            }
+
+            if ("operator" in attrs_item) {
+                // Modify the domain operator to show only the records in directory.
+                domain.forEach(function (item, key) {
+                    if (
+                        item[0] === category.fieldName &&
+                        item[1] !== attrs_item.operator
+                    ) {
+                        domain[key][1] = attrs_item.operator;
+                    }
+                });
+                // Apply domain to show only root directories
+                if (domain.length === 0 && this.config.modelName === "dms.directory") {
+                    domain.push([category.fieldName, "=", false]);
+                }
+            }
+        }
+        return domain;
+    },
+});

--- a/dms/views/directory.xml
+++ b/dms/views/directory.xml
@@ -166,6 +166,7 @@
                         icon="fa-folder"
                         limit="0"
                         enable_counters="1"
+                        operator="="
                     />
                     <field
                         name="category_id"

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -544,6 +544,7 @@
                         icon="fa-folder"
                         limit="0"
                         enable_counters="1"
+                        operator="="
                     />
                     <field
                         name="category_id"

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -233,10 +233,21 @@
                                             class="o_kanban_dms_file_preview"
                                             t-att-data-id="widget.db_id"
                                         >
-                                            <img
-                                                t-att-src="record.icon_url.raw_value"
-                                                alt="Icon"
-                                            />
+                                            <t
+                                                t-if="record.custom_thumbnail_small.raw_value"
+                                            >
+                                                <img
+                                                    t-att-src="kanban_image('dms.file', 'custom_thumbnail_small', record.id.raw_value)"
+                                                    t-att-class="o_kanban_dms_file_preview"
+                                                    alt="Custom thumbnail"
+                                                />
+                                            </t>
+                                            <t t-else="">
+                                                <img
+                                                    t-att-src="record.icon_url.raw_value"
+                                                    alt="Icon"
+                                                />
+                                            </t>
                                         </a>
                                     </div>
                                 </div>
@@ -245,11 +256,6 @@
                                         <div
                                             class="o_kanban_record_title o_text_overflow"
                                         >
-                                            <a
-                                                class="o_kanban_dms_file_preview fa fa-search"
-                                                title="Search"
-                                                t-att-data-id="widget.db_id"
-                                            />
                                             <field name="name" />
                                         </div>
                                         <div class="o_kanban_record_body">

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -300,6 +300,7 @@
                 js_class="file_list"
                 decoration-warning="not active"
                 decoration-muted="(is_locked and not is_lock_editor)"
+                multi_edit="1"
             >
                 <field name="active" invisible="1" />
                 <field name="is_locked" invisible="1" />
@@ -308,7 +309,11 @@
                 <field name="write_date" />
                 <field name="size" widget="integer" />
                 <field name="mimetype" />
-                <field name="path_names" widget="path_names" string="Path" />
+                <field
+                    name="tag_ids"
+                    widget="many2many_tags"
+                    options="{'color_field': 'color', 'no_create_edit': True}"
+                />
             </tree>
         </field>
     </record>

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -233,21 +233,10 @@
                                             class="o_kanban_dms_file_preview"
                                             t-att-data-id="widget.db_id"
                                         >
-                                            <t
-                                                t-if="record.custom_thumbnail_small.raw_value"
-                                            >
-                                                <img
-                                                    t-att-src="kanban_image('dms.file', 'custom_thumbnail_small', record.id.raw_value)"
-                                                    t-att-class="o_kanban_dms_file_preview"
-                                                    alt="Custom thumbnail"
-                                                />
-                                            </t>
-                                            <t t-else="">
-                                                <img
-                                                    t-att-src="record.icon_url.raw_value"
-                                                    alt="Icon"
-                                                />
-                                            </t>
+                                            <img
+                                                t-att-src="record.icon_url.raw_value"
+                                                alt="Icon"
+                                            />
                                         </a>
                                     </div>
                                 </div>


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/dms/pull/122

Changes done:
- [x] [IMP] Changes in file tree view
- [x] [FIX] File preview.
- [x] [IMP]Show in directory kanban view only root directories (Change **All** text to **Root**) + Change to searchpanel _directory_id_ (in files) or _parent_id_ (in directories) to filter equal and not _child_of_ (It's related to https://github.com/OCA/dms/issues/40 )
- [x] [FIX] Display the short name of directories in searchpanel.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT30992