### PR TITLE
[14.0][FIX] dms: Searchpanel from directories

### DIFF
--- a/dms/models/directory.py
+++ b/dms/models/directory.py
@@ -682,3 +682,26 @@ class DmsDirectory(models.Model):
         if self.child_directory_ids:
             self.child_directory_ids.unlink()
         return super().unlink()
+
+    @api.model
+    def _search_panel_domain_image(
+        self, field_name, domain, set_count=False, limit=False
+    ):
+        """We need to overwrite function from directories because odoo only return
+        records with childs (very weird for user perspective).
+        All records are returned now.
+        """
+        if field_name == "parent_id":
+            res = {}
+            for item in self.search_read(
+                domain=domain, fields=["id", "name", "count_directories"]
+            ):
+                res[item["id"]] = {
+                    "id": item["id"],
+                    "display_name": item["name"],
+                    "__count": item["count_directories"],
+                }
+            return res
+        return super()._search_panel_domain_image(
+            field_name=field_name, domain=domain, set_count=set_count, limit=limit
+        )

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -68,12 +68,7 @@
                     />
                 </group>
                 <searchpanel>
-                    <field
-                        name="directory_id"
-                        icon="fa-folder"
-                        context="{'directory_short_name': True}"
-                        enable_counters="1"
-                    />
+                    <field name="directory_id" icon="fa-folder" enable_counters="1" />
                     <field name="category_id" icon="fa-users" enable_counters="1" />
                 </searchpanel>
             </search>

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -68,7 +68,12 @@
                     />
                 </group>
                 <searchpanel>
-                    <field name="directory_id" icon="fa-folder" enable_counters="1" />
+                    <field
+                        name="directory_id"
+                        icon="fa-folder"
+                        enable_counters="1"
+                        operator="="
+                    />
                     <field name="category_id" icon="fa-users" enable_counters="1" />
                 </searchpanel>
             </search>


### PR DESCRIPTION
We need to overwrite function from directories because odoo only return records with childs (very weird for user perspective). All records are returned now.

Related to: https://github.com/OCA/dms/pull/122#issuecomment-1240850412

**Before**
![dms-antes](https://user-images.githubusercontent.com/4117568/189173976-b91a2619-b58f-47d4-9fd7-058880c1bb3a.png)

**After**
![dms-despues](https://user-images.githubusercontent.com/4117568/189174011-cb7f2209-5702-447a-8078-d93282f7e386.png)

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa