### PR TITLE
[14.0][FIX] dms: skip attachment creation when storage type is not attachment

### DIFF
--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -510,7 +510,11 @@ class File(models.Model):
         elif self.env.context.get("default_directory_id"):
             directory_id = self.env.context.get("default_directory_id")
         directory = self.env["dms.directory"].browse(directory_id)
-        if directory.res_model and directory.res_id:
+        if (
+            directory.res_model
+            and directory.res_id
+            and directory.storage_id_save_type == "attachment"
+        ):
             attachment = (
                 self.env["ir.attachment"]
                 .with_context(dms_file=True)


### PR DESCRIPTION
Using the dms_field module, I noticed that when the directory created for the object (partner, ticket and the like) has the values in the model_id and res_id fields, dms creates attachments for files even if the storage type is not attachment.

cc @etobella @jarroyomorales @olgamarcocb @augustodinizl @pedrobaeza 