### PR TITLE
[FIX] Fix opening a directory using the right click open action #212

### DIFF
--- a/dms_field/static/src/js/base/dms_tree_renderer.js
+++ b/dms_field/static/src/js/base/dms_tree_renderer.js
@@ -288,7 +288,7 @@ odoo.define("dms.DmsTreeRenderer", function(require) {
                 icon: "fa fa-external-link",
                 label: _t("Open"),
                 action: function() {
-                    self.trigger_up("dms_open_record", {id: node.id});
+                    self.trigger_up("dms_open_record", {id: node.data.id});
                 },
             };
             return menu;


### PR DESCRIPTION
The root directory can't be opened using the contextual action menu (`open`)

Impacted versions:

    12.0 and above

Steps to reproduce:

    Go to "DMS directories" in the partner form view
    Create a new root directory
    Right-click and choose `Open`

Current behavior:

    Odoo raises an error `TypeError: record is null`

Expected behavior:

    Open the directory like if we click on the `Open` button in the right section (Document preview)