### PR TITLE
[13.0][FIX] dms: Avoid error when accessing a subdirectory without access token

### DIFF
--- a/dms/models/directory.py
+++ b/dms/models/directory.py
@@ -260,7 +260,11 @@ class DmsDirectory(models.Model):
         current_directory = self
         while current_directory:
             directories.insert(0, current_directory)
-            if access_token and consteq(current_directory.access_token, access_token):
+            if (
+                access_token
+                and current_directory.access_token
+                and consteq(current_directory.access_token, access_token)
+            ):
                 return directories
             current_directory = current_directory.parent_id
         if access_token:

--- a/dms/models/dms_security_mixin.py
+++ b/dms/models/dms_security_mixin.py
@@ -102,7 +102,10 @@ class DmsSecurityMixin(models.AbstractModel):
                 self._directory_field,
                 inherited_access_field,
             )
-        inherited_access_domain = [(inherited_access_field, "=", True)]
+        inherited_access_domain = [
+            ("storage_id_save_type", "=", "attachment"),
+            (inherited_access_field, "=", True),
+        ]
         domains = []
         # Get all used related records
         related_groups = self.sudo().read_group(

--- a/dms/views/directory.xml
+++ b/dms/views/directory.xml
@@ -549,7 +549,7 @@
                         </page>
                         <page
                             string="Groups"
-                            attrs="{'invisible':[('storage_id_inherit_access_from_parent_record', '=', True)]}"
+                            attrs="{'invisible':[('storage_id_save_type', '=', 'attachment'),('storage_id_inherit_access_from_parent_record', '=', True)]}"
                         >
                             <field name="group_ids">
                                 <tree string="Groups">
@@ -562,7 +562,7 @@
                         </page>
                         <page
                             string="Complete Groups"
-                            attrs="{'invisible':[('storage_id_inherit_access_from_parent_record', '=', True)]}"
+                            attrs="{'invisible':[('storage_id_save_type', '=', 'attachment'),('storage_id_inherit_access_from_parent_record', '=', True)]}"
                         >
                             <field name="complete_group_ids">
                                 <tree string="Complete Groups">


### PR DESCRIPTION
Misc changes:
- [x] Avoid error when accessing a subdirectory without access token
- [x] Use the correct domain with inherit_access_from_parent_record field

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa