### PR TITLE
[14.0][FIX] dms: Use the correct domain with inherit_access_from_parent_record field

### DIFF
--- a/dms/models/dms_security_mixin.py
+++ b/dms/models/dms_security_mixin.py
@@ -102,7 +102,10 @@ class DmsSecurityMixin(models.AbstractModel):
                 self._directory_field,
                 inherited_access_field,
             )
-        inherited_access_domain = [(inherited_access_field, "=", True)]
+        inherited_access_domain = [
+            ("storage_id_save_type", "=", "attachment"),
+            (inherited_access_field, "=", True),
+        ]
         domains = []
         # Get all used related records
         related_groups = self.sudo().read_group(

--- a/dms/views/directory.xml
+++ b/dms/views/directory.xml
@@ -554,7 +554,7 @@
                         </page>
                         <page
                             string="Groups"
-                            attrs="{'invisible':[('storage_id_inherit_access_from_parent_record', '=', True)]}"
+                            attrs="{'invisible':[('storage_id_save_type', '=', 'attachment'),('storage_id_inherit_access_from_parent_record', '=', True)]}"
                         >
                             <field name="group_ids">
                                 <tree string="Groups">
@@ -567,7 +567,7 @@
                         </page>
                         <page
                             string="Complete Groups"
-                            attrs="{'invisible':[('storage_id_inherit_access_from_parent_record', '=', True)]}"
+                            attrs="{'invisible':[('storage_id_save_type', '=', 'attachment'),('storage_id_inherit_access_from_parent_record', '=', True)]}"
                         >
                             <field name="complete_group_ids">
                                 <tree string="Complete Groups">


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/dms/pull/224

Misc changes:
- [x] Avoid error when accessing a subdirectory without access token (already merged at https://github.com/OCA/dms/commit/e576bb587969c119df02d6fa0edd0554e366e6a8)
- [x] Use the correct domain with inherit_access_from_parent_record field

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa