### PR TITLE
[15.0][FIX] dms: Misc changes.

### DIFF
--- a/dms/models/abstract_dms_mixin.py
+++ b/dms/models/abstract_dms_mixin.py
@@ -37,7 +37,21 @@ class AbstractDmsMixin(models.AbstractModel):
     @api.model
     def search_panel_select_range(self, field_name, **kwargs):
         """Add context to display short folder name."""
-        _self = self.with_context(directory_short_name=True)
+        _self = self.with_context(
+            directory_short_name=True, skip_sanitized_parent_hierarchy=True
+        )
         return super(AbstractDmsMixin, _self).search_panel_select_range(
             field_name, **kwargs
+        )
+
+    def _search_panel_sanitized_parent_hierarchy(self, records, parent_name, ids):
+        if self.env.context.get("skip_sanitized_parent_hierarchy"):
+            all_ids = [value["id"] for value in records]
+            # Prevent error if user not access to parent record
+            for value in records:
+                if value["parent_id"] and value["parent_id"][0] not in all_ids:
+                    value["parent_id"] = False
+            return records
+        return super()._search_panel_sanitized_parent_hierarchy(
+            records=records, parent_name=parent_name, ids=ids
         )

--- a/dms/models/directory.py
+++ b/dms/models/directory.py
@@ -275,11 +275,15 @@ class DmsDirectory(models.Model):
         return directories
 
     def _get_own_root_directories(self):
-        return (
-            self.env["dms.directory"]
-            .search([("is_hidden", "=", False), ("parent_id", "=", False)])
-            .ids
+        res = self.env["dms.directory"].search_read(
+            [("is_hidden", "=", False)], ["parent_id"]
         )
+        all_ids = [value["id"] for value in res]
+        res_ids = []
+        for item in res:
+            if not item["parent_id"] or item["parent_id"][0] not in all_ids:
+                res_ids.append(item["id"])
+        return res_ids
 
     allowed_model_ids = fields.Many2many(
         related="storage_id.model_ids",

--- a/dms/models/directory.py
+++ b/dms/models/directory.py
@@ -258,7 +258,15 @@ class DmsDirectory(models.Model):
         current_directory = self
         while current_directory:
             directories.insert(0, current_directory)
-            if access_token and consteq(current_directory.access_token, access_token):
+            if (
+                (
+                    access_token
+                    and current_directory.access_token
+                    and consteq(current_directory.access_token, access_token)
+                )
+                or not access_token
+                and current_directory.check_access_rights("read")
+            ):
                 return directories
             current_directory = current_directory.parent_id
         if access_token:


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/dms/pull/229

Use case:
- Create a "Documents" directory with access to Admin user.
- Create a "Code" directory with read-only access to the Test (new user) user.
- Create a file in "Code" folder.

Remove `parent_id` defined if you do not have access to it search panel directory.
Before:
![antes-1](https://user-images.githubusercontent.com/4117568/217287766-5d152ba2-54d0-4e82-8096-b611769e1089.png)

After:
![despues-1](https://user-images.githubusercontent.com/4117568/217287843-a93b621f-2081-4270-ac64-91ef470004d4.png)

Get the "parent" directories (those of the top level to which you have access) in the portal view.
Before:
![antes-2](https://user-images.githubusercontent.com/4117568/217287967-85d44b42-5e1b-4f31-a9f1-9596de5f31d5.png)

After:
![despues-2](https://user-images.githubusercontent.com/4117568/217288016-161941cf-c109-432a-b43b-141a85b315f1.png)

Limit breadcrumb from portal to directories you have access to.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT41585