### PR TITLE
[13.0][FIX] dms: dms.file thumbnail generation checks for supported mimetypes 

### DIFF
--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -9,6 +9,8 @@ import json
 import logging
 from collections import defaultdict
 
+from PIL import Image
+
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import ValidationError
 from odoo.osv import expression
@@ -143,7 +145,10 @@ class File(models.Model):
     def _compute_image_1920(self):
         """Provide thumbnail automatically if possible."""
         for one in self.filtered("res_mimetype"):
-            if one.res_mimetype.startswith("image/"):
+            # Image.MIME provides a dict of mimetypes supported by Pillow,
+            # SVG is not present in the dict but is also a supported image format
+            # lacking a better solution, it's being added manually
+            if one.res_mimetype in (*Image.MIME.values(), "image/svg+xml"):
                 one.image_1920 = one.content
 
     def check_access_rule(self, operation):


### PR DESCRIPTION
The method _compute_image_1920 of dms_file checks if the file is of mimetype image and tries to use it as a thumbnail. However, there are several types of image files that Odoo/PIL cannot work with, leading to the following error:

```
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/tools/image.py", line 404, in base64_to_image
    return Image.open(io.BytesIO(base64.b64decode(base64_source)))
  File "/usr/local/lib/python3.6/site-packages/PIL/Image.py", line 2687, in open
    % (filename if filename else fp))
OSError: cannot identify image file <_io.BytesIO object at 0x7f0a6ecb1780>
```

and also further down

```
odoo.exceptions.UserError: ('This file could not be decoded as an image file. Please try with a different file.', '')
```

Examples of such files are CAD files (mimetype: image/vnd.dwg) For a list of all mimetypes starting with "image/" see: https://www.iana.org/assignments/media-types/media-types.xhtml#image