### PR TITLE
[14.0] [IMP] dms: more restrictive access rights for access groups

### DIFF
--- a/dms/security/ir.model.access.csv
+++ b/dms/security/ir.model.access.csv
@@ -19,4 +19,5 @@ access_dms_file_user,dms_file_user,model_dms_file,group_dms_user,1,1,1,1
 
 access_dms_access_group_public,access_dms_access_group_public,model_dms_access_group,base.group_public,1,0,0,0
 access_dms_access_group_portal,access_dms_access_group_portal,model_dms_access_group,base.group_portal,1,0,0,0
-access_security_access_groups_user,access_security_access_groups_user,model_dms_access_group,base.group_user,1,1,1,1
+access_security_access_groups_user,access_security_access_groups_user,model_dms_access_group,base.group_user,1,0,0,0
+access_security_access_groups_dms_user,access_security_access_groups_dms_user,model_dms_access_group,group_dms_user,1,1,1,1

--- a/dms/security/security.xml
+++ b/dms/security/security.xml
@@ -63,9 +63,9 @@
         >['|', ('locked_by', '=', False), ('locked_by', '=', user.id)]</field>
     </record>
     <record id="rule_security_groups_user" model="ir.rule">
-        <field name="name">User can only edit and delete their own groups.</field>
+        <field name="name">DMS users can only edit and delete their own groups.</field>
         <field name="model_id" ref="model_dms_access_group" />
-        <field name="groups" eval="[(4, ref('base.group_user'))]" />
+        <field name="groups" eval="[(4, ref('group_dms_user'))]" />
         <field name="perm_read" eval="0" />
         <field name="perm_create" eval="0" />
         <field name="perm_write" eval="1" />
@@ -73,9 +73,9 @@
         <field name="domain_force">[('create_uid','=',user.id)]</field>
     </record>
     <record id="rule_security_groups_manager" model="ir.rule">
-        <field name="name">Admins can edit and delete all groups.</field>
+        <field name="name">DMS Managers can edit and delete all groups.</field>
         <field name="model_id" ref="model_dms_access_group" />
-        <field name="groups" eval="[(4, ref('base.group_erp_manager'))]" />
+        <field name="groups" eval="[(4, ref('group_dms_manager'))]" />
         <field name="perm_read" eval="0" />
         <field name="perm_create" eval="0" />
         <field name="perm_write" eval="1" />


### PR DESCRIPTION
Change in the permissions for DMS Access Groups:

- Not every user can create new access groups, but only dms_users.
- DMS managers (not admin users) can manage every access group
- Add tests

After this change:

- the base user has read only access
- the group_dms_user can create, and can write and unlink their own groups
- the group_dms_manager can do everything on every group.