### PR TITLE
[14.0] [FIX] Fix filestore-backed file fully transferred to client

### DIFF
--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -396,20 +396,17 @@ class File(models.Model):
 
     @api.depends("content_binary", "content_file", "attachment_id")
     def _compute_content(self):
-        bin_size = self.env.context.get("bin_size", False)
         for record in self:
             if record.content_file:
-                context = {"human_size": True} if bin_size else {"base64": True}
-                record.content = record.with_context(context).content_file
+                record.content = record.content_file
             elif record.content_binary:
                 record.content = (
                     record.content_binary
-                    if bin_size
+                    if self.env.context.get("bin_size")
                     else base64.b64encode(record.content_binary)
                 )
             elif record.attachment_id:
-                context = {"human_size": True} if bin_size else {"base64": True}
-                record.content = record.with_context(context).attachment_id.datas
+                record.content = record.attachment_id.datas
 
     @api.depends("content_binary", "content_file")
     def _compute_save_type(self):

--- a/dms/tests/test_file.py
+++ b/dms/tests/test_file.py
@@ -54,15 +54,17 @@ class FileFilestoreTestCase(StorageFileBaseCase):
         self.assertTrue(lobject_file.content_file)
         self.assertTrue(lobject_file.with_context(bin_size=True).content)
         self.assertTrue(lobject_file.with_context(bin_size=True).content_file)
-        self.assertTrue(lobject_file.with_context(human_size=True).content_file)
-        self.assertTrue(lobject_file.with_context(base64=True).content_file)
-        self.assertTrue(lobject_file.with_context(stream=True).content_file)
-        oid = lobject_file.with_context(oid=True).content_file
-        self.assertTrue(oid)
-        lobject_file.with_context(show_content=True).write(
-            {"content": base64.b64encode(b"\xff new content")}
+        self.assertEqual(lobject_file.content, lobject_file.content_file)
+        self.assertEqual(
+            lobject_file.with_context(bin_size=True).content,
+            lobject_file.with_context(bin_size=True).content_file,
         )
-        self.assertNotEqual(oid, lobject_file.with_context({"oid": True}).content_file)
+        self.assertNotEqual(
+            lobject_file.content, lobject_file.with_context(bin_size=True).content
+        )
+        old_content = lobject_file.content_file
+        lobject_file.write({"content": base64.b64encode(b"\xff new content")})
+        self.assertNotEqual(old_content, lobject_file.content_file)
         self.assertTrue(lobject_file.export_data(["content"]))
         lobject_file.unlink()
 


### PR DESCRIPTION
With this change, the size of the file is transferred to the client instead of the full content of the file

Also removed some context values that were no longer used

#195 