### PR TITLE
[14.0][FIX] dms: Explicitly exclude the pdf type in the image_1920 field of the files

### DIFF
--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -149,7 +149,12 @@ class File(models.Model):
             # Image.MIME provides a dict of mimetypes supported by Pillow,
             # SVG is not present in the dict but is also a supported image format
             # lacking a better solution, it's being added manually
-            if one.mimetype in (*Image.MIME.values(), "image/svg+xml"):
+            # Some component modifies the PIL dictionary by adding PDF as a valid
+            # image type, so it must be explicitly excluded.
+            if one.mimetype != "application/pdf" and one.mimetype in (
+                *Image.MIME.values(),
+                "image/svg+xml",
+            ):
                 one.image_1920 = one.content
 
     def check_access_rule(self, operation):


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/dms/pull/248

Explicitly exclude the pdf type in the `image_1920` field of the files.

Please @pedrobaeza can you review it?

@Tecnativa TT43563