### PR TITLE
[14.0][IMP] DMS: download button in tree and kanban views

### DIFF
--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -315,6 +315,12 @@
                 <field name="is_locked" invisible="1" />
                 <field name="is_lock_editor" invisible="1" />
                 <field name="name" />
+                <field
+                    name="content"
+                    filename="name"
+                    widget="binary"
+                    string="Download"
+                />
                 <field name="write_date" />
                 <field name="size" widget="integer" />
                 <field name="mimetype" />


### PR DESCRIPTION
Really simple PR: add download button in all views so we can avoid to open record formview just to download file which is annoying in general, expecially when we have to download more than one file.

What do you think? 
