### PR TITLE
[FIX] dms: remove padding only for directory kanban records

### DIFF
--- a/dms/static/src/scss/directory_kanban.scss
+++ b/dms/static/src/scss/directory_kanban.scss
@@ -8,6 +8,10 @@
 .mk_directory_kanban_view {
     height: 100%;
     .o_kanban_record {
+        > div:nth-child(1) {
+            padding: 0;
+        }
+
         padding: 0;
         max-height: $o-kanban-image-width + 1;
         .mk_directory_kanban_actions {
@@ -85,14 +89,6 @@
                     border-top: 1px solid gray("300");
                 }
             }
-        }
-    }
-}
-
-.o_kanban_renderer {
-    .o_kanban_record {
-        > div {
-            padding: 0;
         }
     }
 }


### PR DESCRIPTION
16.0 migration added css to remove padding from dms directory kanban records. Inadvertently, it removed padding from *all* kanban view records in odoo.

This commit fixes it by removing the problematic css. Instead, padding is removed only from directory kanban view records, in a manner similar to what file_kanban.scss does for file kanban view.

Fixes #271