### PR TITLE
[15.0][IMP] dms: Show all directories in searchpanel from files

### DIFF
--- a/dms/tests/test_file_database.py
+++ b/dms/tests/test_file_database.py
@@ -119,3 +119,5 @@ class FileDatabaseTestCase(StorageDatabaseBaseCase):
         self.assertTrue(self.file.search_panel_select_range("directory_id"))
         self.assertTrue(self.file.search_panel_select_multi_range("directory_id"))
         self.assertTrue(self.file.search_panel_select_multi_range("tag_ids"))
+        res = self.file.search_panel_select_range("directory_id", enable_counters=True)
+        self.assertTrue(self.directory2.id == x["id"] for x in res["values"])


### PR DESCRIPTION
Show all directories in searchpanel from files

In v13 the `search_panel_select_range()` method (https://github.com/odoo/odoo/blob/13.0/addons/web/models/models.py#L240) returned all directories, now only records that have any files in any directory are returned (this causes that directories without files are not shown).

**v13**:
![13 0-dms](https://github.com/OCA/dms/assets/4117568/e7985223-79be-474d-afb7-98b526c9ee92)

**Before**:
![15 0-dms-antes](https://github.com/OCA/dms/assets/4117568/81d9a1a0-52a4-402f-83c6-f94d50e6f4ca)

**After**:
![15 0-dms-despues](https://github.com/OCA/dms/assets/4117568/19919112-5750-433a-ba37-de7453ad6520)

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT46388