### PR TITLE
[WIP][16.0][FIX] dms: fix directory actions

### DIFF
--- a/dms/static/src/js/views/search_panel.esm.js
+++ b/dms/static/src/js/views/search_panel.esm.js
@@ -22,6 +22,7 @@ patch(SearchModel.prototype, "dms.SearchPanel", {
                     domain.push([category.fieldName, "=", category.activeValueId]);
                 }
                 if (domain.length === 0) {
+                    // / only correct for the main action!
                     domain.push([category.fieldName, "=", false]);
                 }
             }


### PR DESCRIPTION
If the directory is empty, the action would return all files, and the panel show all directories except for the one that triggered the action.

The file count was not consistent with the action if the directory is hidden, since its files would thus also be hidden; this field is a related on the storage, so the value is consistent for the directory and all its files.