### PR TITLE
[15.0][FIX] dms_field: Opening a directory using the right click open action

### DIFF
--- a/dms_field/static/src/js/base/dms_tree_controller.js
+++ b/dms_field/static/src/js/base/dms_tree_controller.js
@@ -408,7 +408,7 @@ odoo.define("dms.DmsTreeController", function (require) {
                 ? "directory_" + directory.parent_id[0]
                 : "#";
             var directoryNode = {
-                id: "directory_" + directory.id,
+                id: dt.id,
                 text: directory.name,
                 icon: "fa fa-folder-o",
                 type: "directory",


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/dms/pull/285

The root directory can't be opened using the contextual action menu (`open`)

Steps to reproduce:

    Go to "DMS directories" in the partner form view
    Create a new root directory
    Right-click and choose `Open`

Current behavior:

    Odoo raises an error `TypeError: record is null`

Expected behavior:

    Open the directory like if we click on the `Open` button in the right section (Document preview)

@Tecnativa