### PR TITLE
[15.0][FIX] dms: Improve the unlink method in base to avoid errors

### DIFF
--- a/dms/models/base.py
+++ b/dms/models/base.py
@@ -1,4 +1,5 @@
 # Copyright 2021 Tecnativa - Jairo Llopis
+# Copyright 2024 Tecnativa - Víctor Martínez
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from odoo import models
@@ -8,12 +9,16 @@ class Base(models.AbstractModel):
     _inherit = "base"
 
     def unlink(self):
-        """Cascade DMS related resources removal."""
+        """Cascade DMS related resources removal.
+        Avoid executing in ir.* models (ir.mode, ir.model.fields, etc), in transient
+        models and in the models we want to check."""
         result = super().unlink()
-        self.env["dms.file"].sudo().search(
-            [("res_model", "=", self._name), ("res_id", "in", self.ids)]
-        ).unlink()
-        self.env["dms.directory"].sudo().search(
-            [("res_model", "=", self._name), ("res_id", "in", self.ids)]
-        ).unlink()
+        if (
+            not self._name.startswith("ir.")
+            and not self.is_transient()
+            and self._name not in ("dms.file", "dms.directory")
+        ):
+            domain = [("res_model", "=", self._name), ("res_id", "in", self.ids)]
+            self.env["dms.file"].sudo().search(domain).unlink()
+            self.env["dms.directory"].sudo().search(domain).unlink()
         return result


### PR DESCRIPTION
Related to: https://github.com/OCA/dms/issues/189

In the uninstall process of dms, checks were made that prevented the removal of fields and models being deleted, also causing the dms_file and dms_directory tables to continue to exist.

Steps to reproduce the error before:
- Install dms
- Uninstall dms
- The dms.file and dms.directory models still exist.
- The tables dms_file and dms_directory in the database still exist.

@Tecnativa