### PR TITLE
[14.0][FIX] dms

### DIFF
--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -375,7 +375,7 @@ class File(models.Model):
                     {
                         "model": model._name,
                         "name": current_dir.name,
-                        "id": current_dir.id,
+                        "id": current_dir._origin.id,
                     },
                 )
                 current_dir = current_dir.parent_id


### PR DESCRIPTION
Error when adding file using the  file_ids field in directories view form.

The current_dir was an object of type NewID and there was a problem serializing it with the json.dumps method.
