### PR TITLE
[15.0][FIX] dms: Fix smartbuttons from files and directories

### DIFF
--- a/dms/models/directory.py
+++ b/dms/models/directory.py
@@ -6,11 +6,12 @@
 import ast
 import base64
 import logging
+from ast import literal_eval
 from collections import defaultdict
 
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import UserError, ValidationError
-from odoo.osv.expression import OR
+from odoo.osv.expression import AND, OR
 from odoo.tools import consteq, human_size
 
 from odoo.addons.http_routing.models.ir_http import slugify
@@ -757,3 +758,39 @@ class DmsDirectory(models.Model):
         return super()._search_panel_domain_image(
             field_name=field_name, domain=domain, set_count=set_count, limit=limit
         )
+
+    def action_dms_directories_all_directory(self):
+        self.ensure_one()
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "dms.action_dms_directory"
+        )
+        domain = AND(
+            [
+                literal_eval(action["domain"].strip()),
+                [("parent_id", "child_of", self.id)],
+            ]
+        )
+        action["domain"] = domain
+        action["context"] = dict(
+            self.env.context,
+            default_parent_id=self.id,
+            searchpanel_default_parent_id=self.id,
+        )
+        return action
+
+    def action_dms_files_all_directory(self):
+        self.ensure_one()
+        action = self.env["ir.actions.act_window"]._for_xml_id("dms.action_dms_file")
+        domain = AND(
+            [
+                literal_eval(action["domain"].strip()),
+                [("directory_id", "child_of", self.id)],
+            ]
+        )
+        action["domain"] = domain
+        action["context"] = dict(
+            self.env.context,
+            default_directory_id=self.id,
+            searchpanel_default_directory_id=self.id,
+        )
+        return action

--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -303,6 +303,18 @@ class File(models.Model):
         (even if some folders have no files)."""
         if field_name == "directory_id":
             domain = [["is_hidden", "=", False]]
+            # If we pass by context something, we filter more about it we filter
+            # the directories of the files or we show all of them
+            if self.env.context.get("active_model", False) == "dms.directory":
+                active_id = self.env.context.get("active_id")
+                # para saber que directorios, buscamos las posibles carpetas que nos interesan
+                files = self.env["dms.file"].search(
+                    [["directory_id", "child_of", active_id]]
+                )
+                all_directories = files.mapped("directory_id")
+                all_directories += files.mapped("directory_id.parent_id")
+                domain.append(["id", "in", all_directories.ids])
+            # Get all possible directories
             comodel_records = (
                 self.env["dms.directory"]
                 .with_context(directory_short_name=True)

--- a/dms/views/directory.xml
+++ b/dms/views/directory.xml
@@ -231,8 +231,8 @@
                                             <h6 class="dropdown-header">Views
                                             </h6>
                                             <a
-                                                type="action"
-                                                name="%(dms.action_dms_directories_all_directory)d"
+                                                type="object"
+                                                name="action_dms_directories_all_directory"
                                                 role="menuitem"
                                                 class="dropdown-item"
                                             >
@@ -240,8 +240,8 @@
                                                 Directories
                                             </a>
                                             <a
-                                                type="action"
-                                                name="%(dms.action_dms_files_all_directory)d"
+                                                type="object"
+                                                name="action_dms_files_all_directory"
                                                 role="menuitem"
                                                 class="dropdown-item"
                                             >
@@ -300,8 +300,8 @@
                                 <div class="mk_directory_kanban_actions">
                                     <div class="mk_directory_kanban_actions_wrapper">
                                         <a
-                                            type="action"
-                                            name="%(dms.action_dms_directories_directory)d"
+                                            type="object"
+                                            name="action_dms_directories_all_directory"
                                             role="button"
                                             class="btn btn-sm btn-outline-primary mk_directory_kanban_directories"
                                             t-att-title="record.count_directories_title.raw_value"
@@ -309,8 +309,8 @@
                                             <i class="fa fa-lg fa-folder" />
                                         </a>
                                         <a
-                                            type="action"
-                                            name="%(dms.action_dms_files_directory)d"
+                                            type="object"
+                                            name="action_dms_files_all_directory"
                                             role="button"
                                             class="btn btn-sm btn-outline-primary mk_directory_kanban_files"
                                             t-att-title="record.count_files_title.raw_value"
@@ -403,8 +403,8 @@
                 <sheet>
                     <div class="oe_button_box" name="button_box">
                         <button
-                            type="action"
-                            name="%(dms.action_dms_directories_all_directory)d"
+                            type="object"
+                            name="action_dms_directories_all_directory"
                             class="oe_stat_button"
                             icon="fa-folder-open-o"
                         >
@@ -415,8 +415,8 @@
                             />
                         </button>
                         <button
-                            type="action"
-                            name="%(dms.action_dms_files_all_directory)d"
+                            type="object"
+                            name="action_dms_files_all_directory"
                             class="oe_stat_button"
                             icon="fa-file-text-o"
                         >


### PR DESCRIPTION
Use case when clicking on smartbutton Files in a directory:
- Only files in that directory or subdirectories are shown.
- Only directory and child subdirectories are displayed in search panel.
- Directory is auto-selected in search panel.

![ejemplo-carpetas](https://github.com/OCA/dms/assets/4117568/c98d55b7-ace0-4974-a908-9019a365e7e4)

Use case when clicking on smartbutton Subdirectories in a directory:
- Only directories in that directory or subdirectories are displayed.
- Directory is auto-selected in search panel.

![ejemplo-archivos](https://github.com/OCA/dms/assets/4117568/d8457f76-964d-4d6c-bb82-099ef80dffb1)

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa 