### PR TITLE
[16.0][FIX] dms: Avoid error when set files from directory form view

### DIFF
--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -395,7 +395,7 @@ class File(models.Model):
                     {
                         "model": model._name,
                         "name": current_dir.name,
-                        "id": current_dir.id,
+                        "id": current_dir._origin.id,
                     },
                 )
                 current_dir = current_dir.parent_id


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/dms/pull/294

Avoid error when set files from directory form view.

Error when adding file using the file_ids field in directories view form.

The current_dir was an object of type NewID and there was a problem serializing it with the json.dumps method.

@Tecnativa