### PR TITLE
[16.0][IMP] dms: Add ACLs to dms.storage for users with the basic permission + Add human_size field to directories and files 

### DIFF
--- a/dms/models/directory.py
+++ b/dms/models/directory.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv.expression import AND, OR
-from odoo.tools import consteq
+from odoo.tools import consteq, human_size
 
 from odoo.addons.http_routing.models.ir_http import slugify
 
@@ -186,6 +186,7 @@ class DmsDirectory(models.Model):
     )
 
     size = fields.Float(compute="_compute_size")
+    human_size = fields.Char(compute="_compute_human_size", string="Size")
 
     inherit_group_ids = fields.Boolean(string="Inherit Groups", default=True)
 
@@ -479,6 +480,11 @@ class DmsDirectory(models.Model):
                 fields=["size"],
             )
             record.size = sum(rec.get("size", 0) for rec in recs)
+
+    @api.depends("size")
+    def _compute_human_size(self):
+        for item in self:
+            item.human_size = human_size(item.size) if item.size else False
 
     @api.depends(
         "group_ids",

--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -104,6 +104,9 @@ class File(models.Model):
     )
 
     size = fields.Float(readonly=True)
+    human_size = fields.Char(
+        readonly=True, string="Size", compute="_compute_human_size", store=True
+    )
 
     checksum = fields.Char(string="Checksum/SHA1", readonly=True, index="btree")
 
@@ -430,6 +433,11 @@ class File(models.Model):
         for record in self:
             binary = base64.b64decode(record.content or "")
             record.mimetype = guess_mimetype(binary)
+
+    @api.depends("size")
+    def _compute_human_size(self):
+        for item in self:
+            item.human_size = human_size(item.size)
 
     @api.depends("content_binary", "content_file", "attachment_id")
     def _compute_content(self):

--- a/dms/security/ir.model.access.csv
+++ b/dms/security/ir.model.access.csv
@@ -3,6 +3,7 @@ id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink
 access_dms_tag_user,dms_tag_user,model_dms_tag,group_dms_user,1,1,1,1
 access_dms_category_user,dms_category_user,model_dms_category,group_dms_user,1,1,1,1
 
+access_dms_storage_base_user,dms_storage_base_user,model_dms_storage,base.group_user,1,0,0,0
 access_dms_storage_portal,dms_storage_portal,model_dms_storage,base.group_portal,1,0,0,0
 access_dms_storage_user,dms_storage_user,model_dms_storage,group_dms_user,1,0,0,0
 access_dms_storage_manager,dms_storage_manager,model_dms_storage,group_dms_manager,1,1,1,1

--- a/dms/views/directory.xml
+++ b/dms/views/directory.xml
@@ -479,7 +479,7 @@
                     </group>
                     <group name="data">
                         <group>
-                            <field name="size" widget="integer" />
+                            <field name="human_size" />
                             <field name="count_elements" string="Elements" />
                         </group>
                         <group>
@@ -533,7 +533,7 @@
                                         string="Directories"
                                     />
                                     <field name="count_total_files" string="Files" />
-                                    <field name="size" widget="integer" />
+                                    <field name="human_size" />
                                 </tree>
                             </field>
                         </page>
@@ -546,7 +546,7 @@
                                 <tree limit="10">
                                     <field name="name" />
                                     <field name="mimetype" />
-                                     <field name="size" widget="integer" />
+                                     <field name="human_size" />
                                     <field name="write_date" readonly="1" />
                                 </tree>
                             </field>

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -323,7 +323,7 @@
                 <field name="is_lock_editor" invisible="1" />
                 <field name="name" />
                 <field name="write_date" />
-                <field name="size" widget="integer" />
+                <field name="human_size" />
                 <field name="mimetype" />
                 <field name="category_id" invisible="1" />
                 <field
@@ -596,7 +596,7 @@
                 <field name="is_lock_editor" invisible="1" />
                 <field name="name" />
                 <field name="write_date" />
-                 <field name="size" widget="integer" />
+                <field name="human_size" />
                 <field name="mimetype" />
                 <field name="storage_id" />
                 <field name="migration" />

--- a/dms/views/storage.xml
+++ b/dms/views/storage.xml
@@ -199,7 +199,7 @@
                                     <field name="name" />
                                     <field name="count_total_directories" />
                                     <field name="count_total_files" />
-                                    <field name="size" />
+                                    <field name="human_size" />
                                 </tree>
                             </field>
                         </page>


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/dms/pull/279

Changes done:
- [x] Add ACLs to `dms.storage` for users with the basic permission.
- [x] Add human_size field to directories and files

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa