### PR TITLE
[15.0][IMP] dms_field: Correctly sort the records (directories and files) in view

### DIFF
--- a/dms_field/static/src/js/base/dms_tree_renderer.js
+++ b/dms_field/static/src/js/base/dms_tree_renderer.js
@@ -72,6 +72,18 @@ odoo.define("dms.DmsTreeRenderer", function (require) {
                 conditionalselect:
                     this.params.conditionalselect || this._checkSelect.bind(this),
                 plugins: plugins,
+                sort: function (a, b) {
+                    // Correctly sort the records according to the type of element
+                    // (folder or file).
+                    // Do not use node.icon because they may have (or will have) a
+                    // different icon for each file according to its extension.
+                    var node_a = this.get_node(a);
+                    var node_b = this.get_node(b);
+                    if (node_a.data.model === node_b.data.model) {
+                        return node_a.text > node_b.text ? 1 : -1;
+                    }
+                    return node_a.data.model > node_b.data.model ? 1 : -1;
+                },
             };
             return tree_config;
         },


### PR DESCRIPTION
Correctly sort the records (directories and files) in view.

**Before**
Incorrect: File is displayed before directories.
![dms_tree-antes](https://github.com/OCA/dms/assets/4117568/661d32be-25db-4728-bfef-1dad85c967a8)

**After**
Correct: All directories are displayed first and then the files.
![dms_tree-despues](https://github.com/OCA/dms/assets/4117568/5d2766ce-5495-4534-9832-574f6f0eff75)

Please @CarlosRoca13 and @chienandalu can you review it?

@Tecnativa TT48181