### PR TITLE
[15.0][FIX] dms_field: Keep dms active when changing view

### DIFF
--- a/dms_field/static/src/js/base/dms_tree_controller.js
+++ b/dms_field/static/src/js/base/dms_tree_controller.js
@@ -321,6 +321,8 @@ odoo.define("dms.DmsTreeController", function (require) {
                             }
                         }.bind(this)
                     );
+                    // Launch _update_overlay to show the drag and drop
+                    this._update_overlay();
                 }.bind(this)
             );
             return data_loaded;


### PR DESCRIPTION
With hr_dms_field
The steps to reproduce the problem are:

1. Open Employee
2. Go to Documents Page
3. Drop a file on a directory
4. Go to another Employee
5. Try to drop a file

The file can not be dropped.

cc @Tecnativa TT48179

ping @victoralmau @pedrobaeza 