### PR TITLE
[16.0][FIX] dms: Change display_name from directory kanban buttons (Directories and Files)

### DIFF
--- a/dms/models/directory.py
+++ b/dms/models/directory.py
@@ -770,6 +770,7 @@ class DmsDirectory(models.Model):
                 [("parent_id", "child_of", self.id)],
             ]
         )
+        action["display_name"] = self.name
         action["domain"] = domain
         action["context"] = dict(
             self.env.context,
@@ -787,6 +788,7 @@ class DmsDirectory(models.Model):
                 [("directory_id", "child_of", self.id)],
             ]
         )
+        action["display_name"] = self.name
         action["domain"] = domain
         action["context"] = dict(
             self.env.context,


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/dms/pull/314

Change `display_name` from directory kanban buttons (Directories and Files)

To avoid inconsistency with the text displayed when clicking on the button, change display_name of the action to directory name.

**Before**:
![antes-carpetas](https://github.com/OCA/dms/assets/4117568/43da7855-f4d1-4c39-b38a-f1238c193f00)
![antes-archivos](https://github.com/OCA/dms/assets/4117568/5c1a6774-4026-40c6-8b2d-1539be196ff2)

**After**:
![despues-directorios](https://github.com/OCA/dms/assets/4117568/0b52eee9-36e1-4dae-9bbf-eecafe334934)
![despues-archivos](https://github.com/OCA/dms/assets/4117568/13810ba8-f9ed-40d4-9c6f-c84a83c8a973)

Please @CarlosRoca13 and @pedrobaeza can you review it?

@Tecnativa TT48180