### PR TITLE
[16.0][IMP] dms: Add default_order to file and directory tree to prevent confusion

### DIFF
--- a/dms/views/directory.xml
+++ b/dms/views/directory.xml
@@ -376,7 +376,7 @@
         <field name="name">dms_directory.tree</field>
         <field name="model">dms.directory</field>
         <field name="arch" type="xml">
-            <tree>
+            <tree default_order="complete_name asc">
                 <field name="name" />
                 <field name="write_date" />
                 <field name="count_files" string="Files" />

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -317,6 +317,7 @@
                 decoration-warning="not active"
                 decoration-muted="(is_locked and not is_lock_editor)"
                 multi_edit="1"
+                default_order="name asc"
             >
                 <field name="active" invisible="1" />
                 <field name="is_locked" invisible="1" />


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/dms/pull/316

Add `default_order` to file and directory tree to prevent confusion

When using searchpanel and there is no default_order, records obtained have no defined order (search_read without order).

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT48180