### PR TITLE
[15.0][IMP] dms_field: Add Parent directory option to templates

### DIFF
--- a/dms_field/i18n/dms_field.pot
+++ b/dms_field/i18n/dms_field.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-04-16 11:00+0000\n"
+"PO-Revision-Date: 2024-04-16 11:00+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -164,7 +166,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:dms_field.field_decimal_precision__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_dms_access_group__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_dms_category__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_dms_classification_template__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_dms_directory__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_dms_field_template__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_dms_file__dms_directory_ids
@@ -174,18 +175,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:dms_field.field_dms_tag__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_fetchmail_server__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_format_address_mixin__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_department__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_departure_reason__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_departure_wizard__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_employee__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_employee_base__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_employee_category__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_employee_public__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_job__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_plan__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_plan_activity_type__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_plan_wizard__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_work_location__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_image_mixin__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_ir_actions_act_url__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_ir_actions_act_window__dms_directory_ids
@@ -321,24 +310,13 @@ msgstr ""
 #: model:ir.model.fields,field_description:dms_field.field_res_users_apikeys_show__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_res_users_identitycheck__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_res_users_log__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_res_users_role__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_res_users_role_line__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_res_users_settings__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_res_users_settings_volumes__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_reset_view_arch_wizard__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_resource_calendar__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_resource_calendar_attendance__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_resource_calendar_leaves__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_resource_mixin__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_resource_resource__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_resource_test__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_web_editor_assets__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_web_editor_converter_test_sub__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_web_tour_tour__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_wizard_dms_classification__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_wizard_dms_classification_detail__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_wizard_dms_file_move__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_wizard_groups_into_role__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_wizard_ir_model_menu_create__dms_directory_ids
 msgid "DMS Directories"
 msgstr ""
@@ -366,12 +344,6 @@ msgstr ""
 #. module: dms_field
 #: model:ir.model,name:dms_field.model_dms_directory
 msgid "Directory"
-msgstr ""
-
-#. module: dms_field
-#: code:addons/dms_field/models/dms_directory.py:0
-#, python-format
-msgid "Directory %s must be root in order to be related to a record"
 msgstr ""
 
 #. module: dms_field
@@ -580,6 +552,11 @@ msgstr ""
 #. module: dms_field
 #: model:ir.model.fields,field_description:dms_field.field_dms_directory__parent_id
 msgid "Parent Directory"
+msgstr ""
+
+#. module: dms_field
+#: model:ir.model.fields,field_description:dms_field.field_dms_field_template__parent_directory_id
+msgid "Parent directory"
 msgstr ""
 
 #. module: dms_field

--- a/dms_field/i18n/es.po
+++ b/dms_field/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-07 15:56+0000\n"
-"PO-Revision-Date: 2024-03-23 09:34+0000\n"
+"POT-Creation-Date: 2024-04-16 11:00+0000\n"
+"PO-Revision-Date: 2024-04-16 13:01+0200\n"
 "Last-Translator: Ivorra78 <informatica@totmaterial.es>\n"
 "Language-Team: none\n"
 "Language: es\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.17\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. module: dms_field
 #. openerp-web
@@ -168,7 +168,6 @@ msgstr "DMS"
 #: model:ir.model.fields,field_description:dms_field.field_decimal_precision__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_dms_access_group__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_dms_category__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_dms_classification_template__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_dms_directory__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_dms_field_template__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_dms_file__dms_directory_ids
@@ -178,18 +177,6 @@ msgstr "DMS"
 #: model:ir.model.fields,field_description:dms_field.field_dms_tag__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_fetchmail_server__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_format_address_mixin__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_department__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_departure_reason__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_departure_wizard__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_employee__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_employee_base__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_employee_category__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_employee_public__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_job__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_plan__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_plan_activity_type__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_plan_wizard__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_hr_work_location__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_image_mixin__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_ir_actions_act_url__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_ir_actions_act_window__dms_directory_ids
@@ -325,24 +312,13 @@ msgstr "DMS"
 #: model:ir.model.fields,field_description:dms_field.field_res_users_apikeys_show__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_res_users_identitycheck__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_res_users_log__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_res_users_role__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_res_users_role_line__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_res_users_settings__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_res_users_settings_volumes__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_reset_view_arch_wizard__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_resource_calendar__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_resource_calendar_attendance__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_resource_calendar_leaves__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_resource_mixin__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_resource_resource__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_resource_test__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_web_editor_assets__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_web_editor_converter_test_sub__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_web_tour_tour__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_wizard_dms_classification__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_wizard_dms_classification_detail__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_wizard_dms_file_move__dms_directory_ids
-#: model:ir.model.fields,field_description:dms_field.field_wizard_groups_into_role__dms_directory_ids
 #: model:ir.model.fields,field_description:dms_field.field_wizard_ir_model_menu_create__dms_directory_ids
 msgid "DMS Directories"
 msgstr "Directorios DMS"
@@ -373,14 +349,6 @@ msgstr ""
 #: model:ir.model,name:dms_field.model_dms_directory
 msgid "Directory"
 msgstr "Directorio"
-
-#. module: dms_field
-#: code:addons/dms_field/models/dms_directory.py:0
-#, python-format
-msgid "Directory %s must be root in order to be related to a record"
-msgstr ""
-"Directorio %s debede ser raíz en la orden para estar relacionado con un "
-"registro"
 
 #. module: dms_field
 #: model:ir.model.fields,field_description:dms_field.field_dms_field_template__directory_format_name
@@ -588,6 +556,11 @@ msgstr "Abrir "
 #: model:ir.model.fields,field_description:dms_field.field_dms_directory__parent_id
 msgid "Parent Directory"
 msgstr "Directorio parental"
+
+#. module: dms_field
+#: model:ir.model.fields,field_description:dms_field.field_dms_field_template__parent_directory_id
+msgid "Parent directory"
+msgstr "Carpeta padre"
 
 #. module: dms_field
 #. openerp-web

--- a/dms_field/models/dms_directory.py
+++ b/dms_field/models/dms_directory.py
@@ -30,18 +30,12 @@ class DmsDirectory(models.Model):
                 )
             if not directory.res_id:
                 continue
-            if not directory.is_root_directory:
-                raise ValidationError(
-                    _("Directory %s must be root in order to be related to a " "record")
-                    % directory.display_name
-                )
             if self.search(
                 [
                     ("storage_id", "=", directory.storage_id.id),
                     ("id", "!=", directory.id),
                     ("res_id", "=", directory.res_id),
                     ("res_model", "=", directory.res_model),
-                    ("is_root_directory", "=", True),
                 ],
                 limit=1,
             ):

--- a/dms_field/models/dms_field_template.py
+++ b/dms_field/models/dms_field_template.py
@@ -20,6 +20,11 @@ class DmsFieldTemplate(models.Model):
         domain=[("save_type", "!=", "attachment")],
         string="Storage",
     )
+    parent_directory_id = fields.Many2one(
+        comodel_name="dms.directory",
+        domain="[('storage_id', '=', storage_id)]",
+        string="Parent directory",
+    )
     model_id = fields.Many2one(
         comodel_name="ir.model",
         string="Model",
@@ -77,7 +82,7 @@ class DmsFieldTemplate(models.Model):
             raise ValidationError(_("There is no template linked to this model"))
         total_directories = directory_model.search_count(
             [
-                ("is_root_directory", "=", True),
+                ("parent_id", "=", self.parent_directory_id.id),
                 ("res_model", "=", res_model),
                 ("res_id", "=", res_id),
             ]
@@ -138,11 +143,17 @@ class DmsFieldTemplate(models.Model):
             record.ids,
             engine="inline_template",
         )[record.id]
-        return {
+        vals = {
             "storage_id": directory.storage_id.id,
             "res_id": record.id,
             "res_model": record._name,
-            "is_root_directory": directory.is_root_directory,
             "name": directory_name,
             "group_ids": [(4, group.id) for group in groups],
         }
+        if not self.parent_directory_id:
+            vals.update({"is_root_directory": True})
+        else:
+            vals.update(
+                {"parent_id": self.parent_directory_id.id, "inherit_group_ids": False}
+            )
+        return vals

--- a/dms_field/tests/test_dms_field.py
+++ b/dms_field/tests/test_dms_field.py
@@ -2,6 +2,7 @@
 # Copyright 2024 Tecnativa - Víctor Martínez
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
+from odoo import fields
 from odoo.exceptions import ValidationError
 from odoo.tests import TransactionCase, new_test_user
 
@@ -115,6 +116,9 @@ class TestDmsField(TransactionCase):
         self.assertEqual(self.partner.dms_directory_ids.name, self.partner.display_name)
         child_names = self.partner.dms_directory_ids.mapped("child_directory_ids.name")
         directory_0 = self.partner.dms_directory_ids[0]
+        self.assertFalse(directory_0.parent_id)
+        self.assertTrue(directory_0.is_root_directory)
+        self.assertTrue(directory_0.inherit_group_ids)
         self.assertNotIn(self.template.group_ids, directory_0.group_ids)
         self.assertIn(self.group, directory_0.group_ids.group_ids)
         self.assertIn(self.user_b, directory_0.group_ids.explicit_user_ids)
@@ -125,10 +129,52 @@ class TestDmsField(TransactionCase):
         with self.assertRaises(ValidationError):
             template.create_dms_directory()
 
+    def test_creation_process_01_with_parent(self):
+        self.assertFalse(self.partner.dms_directory_ids)
+        self.template.parent_directory_id = fields.first(
+            self.template.storage_id.root_directory_ids
+        )
+        template = self.env["dms.field.template"].with_context(
+            res_model=self.partner._name, res_id=self.partner.id
+        )
+        template.create_dms_directory()
+        self.partner.refresh()
+        self.assertEqual(self.partner.dms_directory_ids.name, self.partner.display_name)
+        directory_0 = self.partner.dms_directory_ids[0]
+        self.assertEqual(directory_0.parent_id, self.template.parent_directory_id)
+        self.assertFalse(directory_0.is_root_directory)
+        self.assertFalse(directory_0.inherit_group_ids)
+        self.assertNotIn(self.template.group_ids, directory_0.group_ids)
+        self.assertIn(self.group, directory_0.group_ids.group_ids)
+        self.assertIn(self.user_b, directory_0.group_ids.explicit_user_ids)
+        self.assertIn(self.user_a, directory_0.group_ids.users)
+        self.assertIn(self.user_b, directory_0.group_ids.users)
+
     def test_creation_process_02(self):
         partner_1 = self.env["res.partner"].create({"name": "Test partner 1"})
         partner_1.refresh()
-        self.assertTrue(partner_1.dms_directory_ids)
+        directory_1 = partner_1.dms_directory_ids[0]
+        self.assertFalse(directory_1.parent_id)
+        self.assertTrue(directory_1.is_root_directory)
+        self.assertTrue(directory_1.inherit_group_ids)
+        partner_2 = (
+            self.env["res.partner"]
+            .with_context(skip_track_dms_field_template=True)
+            .create({"name": "Test partner 2"})
+        )
+        partner_2.refresh()
+        self.assertFalse(partner_2.dms_directory_ids)
+
+    def test_creation_process_02_with_parent(self):
+        self.template.parent_directory_id = fields.first(
+            self.template.storage_id.root_directory_ids
+        )
+        partner_1 = self.env["res.partner"].create({"name": "Test partner 1"})
+        partner_1.refresh()
+        directory_1 = partner_1.dms_directory_ids[0]
+        self.assertEqual(directory_1.parent_id, self.template.parent_directory_id)
+        self.assertFalse(directory_1.is_root_directory)
+        self.assertFalse(directory_1.inherit_group_ids)
         partner_2 = (
             self.env["res.partner"]
             .with_context(skip_track_dms_field_template=True)

--- a/dms_field/views/dms_field_template_views.xml
+++ b/dms_field/views/dms_field_template_views.xml
@@ -25,6 +25,10 @@
                         <field name="company_id" groups="base.group_multi_company" />
                         <field name="dms_directory_ids" invisible="1" />
                         <field name="storage_id" required="1" />
+                        <field
+                            name="parent_directory_id"
+                            attrs="{'invisible':[('storage_id', '=', False)]}"
+                        />
                         <field name="model_id" required="1" />
                         <field
                             name="user_field_id"


### PR DESCRIPTION
A parent directory can be set in templates, if set, the directory that is created linked to a record will be a "child" of that directory.

Please @chienandalu and @pedrobaeza can you review it?

@Tecnativa TT48650