### PR TITLE
[16.0][IMP] dms: Add number items (directories and files) to directory kanban view

### DIFF
--- a/dms/static/src/scss/directory_kanban.scss
+++ b/dms/static/src/scss/directory_kanban.scss
@@ -31,10 +31,14 @@
                         border-bottom: solid 1px $gray-400;
                     }
                 }
+                span.total_items {
+                    margin-left: 3px;
+                    margin-top: 3px;
+                }
             }
         }
         .o_kanban_image {
-            width: $o-kanban-image-width + 1;
+            width: $o-kanban-image-width - 1;
             border-right: solid 1px $gray-400;
             + div {
                 padding-left: $o-kanban-image-width + $o-kanban-inside-hgutter +

--- a/dms/views/directory.xml
+++ b/dms/views/directory.xml
@@ -208,6 +208,8 @@
                 <field name="count_files" />
                 <field name="count_directories_title" />
                 <field name="count_files_title" />
+                <field name="count_total_directories" />
+                <field name="count_total_files" />
                 <templates>
                     <t t-name="kanban-box">
                         <div
@@ -305,7 +307,11 @@
                                             class="btn btn-sm btn-outline-primary mk_directory_kanban_directories"
                                             t-att-title="record.count_directories_title.raw_value"
                                         >
-                                            <i class="fa fa-lg fa-folder" />
+                                            <i class="fa fa-xs fa-folder" />
+                                            <span
+                                                class="total_items"
+                                                t-esc="record.count_total_directories.raw_value"
+                                            />
                                         </a>
                                         <a
                                             type="object"
@@ -314,7 +320,11 @@
                                             class="btn btn-sm btn-outline-primary mk_directory_kanban_files"
                                             t-att-title="record.count_files_title.raw_value"
                                         >
-                                            <i class="fa fa-lg fa-file" />
+                                            <i class="fa fa-xs fa-file" />
+                                            <span
+                                                class="total_items"
+                                                t-esc="record.count_total_files.raw_value"
+                                            />
                                         </a>
                                     </div>
                                 </div>


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/dms/pull/324

Add number items (directories and files) to directory kanban view.

![ejemplo](https://github.com/OCA/dms/assets/4117568/9f654383-fcdf-4919-9860-1422e165ce86)

Please @chienandalu and @pedrobaeza can you review it?

@Tecnativa TT48648