### PR TITLE
[16.0][FIX]dms: error when clicked the file smart button.

### DIFF
--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -353,7 +353,8 @@ class File(models.Model):
             if enable_counters:
                 res = super().search_panel_select_range(field_name, **kwargs)
                 for item in res["values"]:
-                    field_range[item["id"]]["__count"] = item["__count"]
+                    if item["id"] in field_range:
+                        field_range[item["id"]]["__count"] = item["__count"]
             return {"parent_field": "parent_id", "values": list(field_range.values())}
         context = {}
         if field_name == "category_id":


### PR DESCRIPTION
There is an error using the smart files button when the directory structure has some subdirectory without files and a directory with files inside the empty directory.

Error screenshot:
![image](https://github.com/OCA/dms/assets/128601880/8f6998ba-1321-42aa-bdba-1170e8750df0)


Steps to reproduce the error (I'm using the runbot for reproduce the error):
http://oca-dms-16-0-c218b73a988a.runboat.odoo-community.org/web#action=170&model=dms.directory&view_type=kanban&cids=1&menu_id=106

- Fist create the next directory estructure:
       Test1/Test2/Test3.
-  Now create any file in Test3.
- Go to any directory and use the smart button.

I suppose that the error is due to the fact that the id of the empty directory is not in the field_range, because if a file is added to the test2 directory that error is not generated.

Thanks for your time. 
 






