### PR TITLE
[16.0][IMP] dms: Remove string=Size from the human_size field to avoid the warning of 2 fields with the same string.

### DIFF
--- a/dms/i18n/dms.pot
+++ b/dms/i18n/dms.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-05-20 08:48+0000\n"
+"PO-Revision-Date: 2024-05-20 08:48+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -238,8 +240,8 @@ msgid "A file with the same name already exists"
 msgstr ""
 
 #. module: dms
-#. odoo-python
 #. odoo-javascript
+#. odoo-python
 #: code:addons/dms/models/dms_file.py:0
 #: code:addons/dms/static/src/js/views/dms_file_upload.esm.js:0
 #, python-format
@@ -1843,13 +1845,21 @@ msgid "Single Files"
 msgstr ""
 
 #. module: dms
-#: model:ir.model.fields,field_description:dms.field_dms_directory__human_size
 #: model:ir.model.fields,field_description:dms.field_dms_directory__size
-#: model:ir.model.fields,field_description:dms.field_dms_file__human_size
 #: model:ir.model.fields,field_description:dms.field_dms_file__size
 #: model:ir.model.fields,field_description:dms.field_res_config_settings__documents_binary_max_size
 #: model_terms:ir.ui.view,arch_db:dms.portal_my_dms
+#: model_terms:ir.ui.view,arch_db:dms.view_dms_directory_form
+#: model_terms:ir.ui.view,arch_db:dms.view_dms_file_migration_tree
+#: model_terms:ir.ui.view,arch_db:dms.view_dms_file_tree
+#: model_terms:ir.ui.view,arch_db:dms.view_dms_storage_form
 msgid "Size"
+msgstr ""
+
+#. module: dms
+#: model:ir.model.fields,field_description:dms.field_dms_directory__human_size
+#: model:ir.model.fields,field_description:dms.field_dms_file__human_size
+msgid "Size (human readable)"
 msgstr ""
 
 #. module: dms

--- a/dms/i18n/es.po
+++ b/dms/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-27 10:07+0000\n"
-"PO-Revision-Date: 2024-03-27 11:08+0100\n"
+"POT-Creation-Date: 2024-05-20 08:48+0000\n"
+"PO-Revision-Date: 2024-05-20 10:49+0200\n"
 "Last-Translator: Ivorra78 <informatica@totmaterial.es>\n"
 "Language-Team: none\n"
 "Language: es\n"
@@ -308,8 +308,8 @@ msgid "A file with the same name already exists"
 msgstr "Ya existe un archivo con el mismo nombre"
 
 #. module: dms
-#. odoo-python
 #. odoo-javascript
+#. odoo-python
 #: code:addons/dms/models/dms_file.py:0
 #: code:addons/dms/static/src/js/views/dms_file_upload.esm.js:0
 #, python-format
@@ -1945,14 +1945,22 @@ msgid "Single Files"
 msgstr "Archivos individuales"
 
 #. module: dms
-#: model:ir.model.fields,field_description:dms.field_dms_directory__human_size
 #: model:ir.model.fields,field_description:dms.field_dms_directory__size
-#: model:ir.model.fields,field_description:dms.field_dms_file__human_size
 #: model:ir.model.fields,field_description:dms.field_dms_file__size
 #: model:ir.model.fields,field_description:dms.field_res_config_settings__documents_binary_max_size
 #: model_terms:ir.ui.view,arch_db:dms.portal_my_dms
+#: model_terms:ir.ui.view,arch_db:dms.view_dms_directory_form
+#: model_terms:ir.ui.view,arch_db:dms.view_dms_file_migration_tree
+#: model_terms:ir.ui.view,arch_db:dms.view_dms_file_tree
+#: model_terms:ir.ui.view,arch_db:dms.view_dms_storage_form
 msgid "Size"
 msgstr "Tamaño"
+
+#. module: dms
+#: model:ir.model.fields,field_description:dms.field_dms_directory__human_size
+#: model:ir.model.fields,field_description:dms.field_dms_file__human_size
+msgid "Size (human readable)"
+msgstr ""
 
 #. module: dms
 #: model:ir.model.fields,field_description:dms.field_dms_directory__starred

--- a/dms/models/directory.py
+++ b/dms/models/directory.py
@@ -186,7 +186,9 @@ class DmsDirectory(models.Model):
     )
 
     size = fields.Float(compute="_compute_size")
-    human_size = fields.Char(compute="_compute_human_size", string="Size")
+    human_size = fields.Char(
+        compute="_compute_human_size", string="Size (human readable)"
+    )
 
     inherit_group_ids = fields.Boolean(string="Inherit Groups", default=True)
 

--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -106,7 +106,10 @@ class File(models.Model):
 
     size = fields.Float(readonly=True)
     human_size = fields.Char(
-        readonly=True, string="Size", compute="_compute_human_size", store=True
+        readonly=True,
+        string="Size (human readable)",
+        compute="_compute_human_size",
+        store=True,
     )
 
     checksum = fields.Char(string="Checksum/SHA1", readonly=True, index="btree")

--- a/dms/views/directory.xml
+++ b/dms/views/directory.xml
@@ -489,7 +489,7 @@
                     </group>
                     <group name="data">
                         <group>
-                            <field name="human_size" />
+                            <field name="human_size" string="Size" />
                             <field name="count_elements" string="Elements" />
                         </group>
                         <group>
@@ -543,7 +543,7 @@
                                         string="Directories"
                                     />
                                     <field name="count_total_files" string="Files" />
-                                    <field name="human_size" />
+                                    <field name="human_size" string="Size" />
                                 </tree>
                             </field>
                         </page>
@@ -556,7 +556,7 @@
                                 <tree limit="10">
                                     <field name="name" />
                                     <field name="mimetype" />
-                                     <field name="human_size" />
+                                     <field name="human_size" string="Size" />
                                     <field name="write_date" readonly="1" />
                                 </tree>
                             </field>

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -326,7 +326,7 @@
                 <field name="directory_id" optional="hide" />
                 <field name="root_directory_id" optional="hide" />
                 <field name="write_date" />
-                <field name="human_size" />
+                <field name="human_size" string="Size" />
                 <field name="mimetype" />
                 <field name="category_id" invisible="1" />
                 <field
@@ -599,7 +599,7 @@
                 <field name="is_lock_editor" invisible="1" />
                 <field name="name" />
                 <field name="write_date" />
-                <field name="human_size" />
+                <field name="human_size" string="Size" />
                 <field name="mimetype" />
                 <field name="storage_id" />
                 <field name="migration" />

--- a/dms/views/storage.xml
+++ b/dms/views/storage.xml
@@ -199,7 +199,7 @@
                                     <field name="name" />
                                     <field name="count_total_directories" />
                                     <field name="count_total_files" />
-                                    <field name="human_size" />
+                                    <field name="human_size" string="Size" />
                                 </tree>
                             </field>
                         </page>


### PR DESCRIPTION
Fixes https://github.com/OCA/dms/issues/333

Remove string=Size from the `human_size` field to avoid the warning of 2 fields with the same string.

Please @pedrobaeza can you review it?

@Tecnativa