### PR TITLE
[15.0][IMP] dms_field: Add #id from record to auto-generate access group to prevent error

### DIFF
--- a/dms_field/i18n/dms_field.pot
+++ b/dms_field/i18n/dms_field.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-05-20 11:48+0000\n"
+"PO-Revision-Date: 2024-05-20 11:48+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -49,7 +51,7 @@ msgstr ""
 #. module: dms_field
 #: code:addons/dms_field/models/dms_field_template.py:0
 #, python-format
-msgid "Autogenerate group from %(model)s (%(name)s)"
+msgid "Autogenerate group from %(model)s (%(name)s) #%(id)s"
 msgstr ""
 
 #. module: dms_field

--- a/dms_field/i18n/es.po
+++ b/dms_field/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-16 11:00+0000\n"
-"PO-Revision-Date: 2024-04-16 13:01+0200\n"
+"POT-Creation-Date: 2024-05-20 11:48+0000\n"
+"PO-Revision-Date: 2024-05-20 13:49+0200\n"
 "Last-Translator: Ivorra78 <informatica@totmaterial.es>\n"
 "Language-Team: none\n"
 "Language: es\n"
@@ -53,8 +53,8 @@ msgstr "Agregar archivo: "
 #. module: dms_field
 #: code:addons/dms_field/models/dms_field_template.py:0
 #, python-format
-msgid "Autogenerate group from %(model)s (%(name)s)"
-msgstr "Grupo autogenerado desde %(model)s (%(name)s)"
+msgid "Autogenerate group from %(model)s (%(name)s) #%(id)s"
+msgstr "Grupo autogenerado desde %(model)s (%(name)s) #%(id)s"
 
 #. module: dms_field
 #: model:ir.model,name:dms_field.model_base

--- a/dms_field/models/dms_field_template.py
+++ b/dms_field/models/dms_field_template.py
@@ -106,9 +106,10 @@ class DmsFieldTemplate(models.Model):
     def _set_groups_from_directory(self, directory, record):
         groups = self.env["dms.access.group"]
         for group in directory.group_ids:
-            group_name = _("Autogenerate group from %(model)s (%(name)s)") % {
+            group_name = _("Autogenerate group from %(model)s (%(name)s) #%(id)s") % {
                 "model": record._description,
                 "name": record.display_name,
+                "id": record.id,
             }
             new_group = group.copy({"name": group_name, "directory_ids": False})
             # Apply sudo() because the user may not have permissions to access

--- a/dms_field/tests/test_dms_field.py
+++ b/dms_field/tests/test_dms_field.py
@@ -149,6 +149,9 @@ class TestDmsField(TransactionCase):
         self.assertIn(self.user_b, directory_0.group_ids.explicit_user_ids)
         self.assertIn(self.user_a, directory_0.group_ids.users)
         self.assertIn(self.user_b, directory_0.group_ids.users)
+        # Create new partner (same name) process to prevent error in dms access group
+        partner2 = self.env["res.partner"].create({"name": self.partner.name})
+        partner2.refresh()
 
     def test_creation_process_02(self):
         partner_1 = self.env["res.partner"].create({"name": "Test partner 1"})


### PR DESCRIPTION
Add #id from record to auto-generate access group to prevent error

Example use case:
- Create an employee in company A (auto-generated group is created).
- Archive employee
- Create the same employee in company B (auto-generated group is created).

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT49176