### PR TITLE
[16.0][FIX] dms: Remove incorrect character in maximum upload size error message

### DIFF
--- a/dms/i18n/de.po
+++ b/dms/i18n/de.po
@@ -2122,7 +2122,7 @@ msgstr "Der Name der Datei ist ungültig."
 #. odoo-python
 #: code:addons/dms/models/dms_file.py:0
 #, python-format
-msgid "The maximum upload size is %s MB)."
+msgid "The maximum upload size is %s MB."
 msgstr "Die maximale Upload-Größe beträgt %s MB."
 
 #. module: dms

--- a/dms/i18n/dms.pot
+++ b/dms/i18n/dms.pot
@@ -2019,7 +2019,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/dms/models/dms_file.py:0
 #, python-format
-msgid "The maximum upload size is %s MB)."
+msgid "The maximum upload size is %s MB."
 msgstr ""
 
 #. module: dms

--- a/dms/i18n/es.po
+++ b/dms/i18n/es.po
@@ -2125,8 +2125,8 @@ msgstr "El nombre de archivo es inválido."
 #. odoo-python
 #: code:addons/dms/models/dms_file.py:0
 #, python-format
-msgid "The maximum upload size is %s MB)."
-msgstr "El tamaño máximo de subida es %s MB)."
+msgid "The maximum upload size is %s MB."
+msgstr "El tamaño máximo de subida es %s MB."
 
 #. module: dms
 #: model:ir.model.fields,help:dms.field_dms_directory__alias_model_id

--- a/dms/i18n/fr.po
+++ b/dms/i18n/fr.po
@@ -2112,8 +2112,8 @@ msgstr "Le nom du fichier n'est pas valide."
 #. odoo-python
 #: code:addons/dms/models/dms_file.py:0
 #, python-format
-msgid "The maximum upload size is %s MB)."
-msgstr "La taille de téléchargement maximale est de %s Mo)."
+msgid "The maximum upload size is %s MB."
+msgstr "La taille de téléchargement maximale est de %s Mo."
 
 #. module: dms
 #: model:ir.model.fields,help:dms.field_dms_directory__alias_model_id

--- a/dms/i18n/he_IL.po
+++ b/dms/i18n/he_IL.po
@@ -2046,8 +2046,8 @@ msgstr "שם הקובץ אינו חוקי."
 #. odoo-python
 #: code:addons/dms/models/dms_file.py:0
 #, python-format
-msgid "The maximum upload size is %s MB)."
-msgstr "גודל ההעלאה המקסימלי הוא %s MB)."
+msgid "The maximum upload size is %s MB."
+msgstr "גודל ההעלאה המקסימלי הוא %s MB."
 
 #. module: dms
 #: model:ir.model.fields,help:dms.field_dms_directory__alias_model_id

--- a/dms/i18n/it.po
+++ b/dms/i18n/it.po
@@ -2122,8 +2122,8 @@ msgstr "Il nome del file non è valido."
 #. odoo-python
 #: code:addons/dms/models/dms_file.py:0
 #, python-format
-msgid "The maximum upload size is %s MB)."
-msgstr "La dimensione massima di upload è %s MB)."
+msgid "The maximum upload size is %s MB."
+msgstr "La dimensione massima di upload è %s MB."
 
 #. module: dms
 #: model:ir.model.fields,help:dms.field_dms_directory__alias_model_id

--- a/dms/i18n/nl.po
+++ b/dms/i18n/nl.po
@@ -2025,7 +2025,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/dms/models/dms_file.py:0
 #, python-format
-msgid "The maximum upload size is %s MB)."
+msgid "The maximum upload size is %s MB."
 msgstr ""
 
 #. module: dms

--- a/dms/i18n/pt.po
+++ b/dms/i18n/pt.po
@@ -2112,8 +2112,8 @@ msgstr "O nome do arquivo é inválido."
 #. odoo-python
 #: code:addons/dms/models/dms_file.py:0
 #, python-format
-msgid "The maximum upload size is %s MB)."
-msgstr "O tamanho máximo de upload é %s MB)."
+msgid "The maximum upload size is %s MB."
+msgstr "O tamanho máximo de upload é %s MB."
 
 #. module: dms
 #: model:ir.model.fields,help:dms.field_dms_directory__alias_model_id

--- a/dms/i18n/pt_BR.po
+++ b/dms/i18n/pt_BR.po
@@ -2111,8 +2111,8 @@ msgstr "O nome do arquivo é inválido."
 #. odoo-python
 #: code:addons/dms/models/dms_file.py:0
 #, python-format
-msgid "The maximum upload size is %s MB)."
-msgstr "O tamanho máximo de upload é %s MB)."
+msgid "The maximum upload size is %s MB."
+msgstr "O tamanho máximo de upload é %s MB."
 
 #. module: dms
 #: model:ir.model.fields,help:dms.field_dms_directory__alias_model_id

--- a/dms/i18n/ru.po
+++ b/dms/i18n/ru.po
@@ -2024,7 +2024,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/dms/models/dms_file.py:0
 #, python-format
-msgid "The maximum upload size is %s MB)."
+msgid "The maximum upload size is %s MB."
 msgstr ""
 
 #. module: dms

--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -548,8 +548,7 @@ class File(models.Model):
         for record in self:
             if record.size and record.size > self._get_binary_max_size() * 1024 * 1024:
                 raise ValidationError(
-                    _("The maximum upload size is %s MB).")
-                    % self._get_binary_max_size()
+                    _("The maximum upload size is %s MB.") % self._get_binary_max_size()
                 )
 
     # ----------------------------------------------------------


### PR DESCRIPTION
Remove incorrect character in maximum upload size error message

Related to #https://github.com/OCA/dms/issues/337

@Tecnativa