### PR TITLE
[IMP] dms: Capture correct error to be shown at notification

### DIFF
--- a/dms/static/src/js/views/dms_file_upload.esm.js
+++ b/dms/static/src/js/views/dms_file_upload.esm.js
@@ -1,7 +1,6 @@
 /** @odoo-module */
 
 import {useBus, useService} from "@web/core/utils/hooks";
-import rpc from "web.rpc";
 import {_t} from "web.core";
 
 const {useRef, useEffect, useState} = owl;
@@ -149,26 +148,17 @@ export const FileUpload = {
             });
         });
 
-        rpc.query({
-            model: "dms.file",
-            method: "create",
-            args: [attachments_args],
-            kwargs: {
+        this.orm
+            .call("dms.file", "create", [attachments_args], {
                 context: ctx,
-            },
-        })
+            })
             .then(() => {
                 self.actionService.restore(controllerID);
             })
             .catch((error) => {
-                console.log("##error##: ", error);
-                window.alert(this.env._t("A file with the same name already exists."));
-                self.notification.add(
-                    this.env._t("A file with the same name already exists"),
-                    {
-                        type: "danger",
-                    }
-                );
+                self.notification.add(error.data.message, {
+                    type: "danger",
+                });
                 self.actionService.restore(controllerID);
             });
     },


### PR DESCRIPTION
Until now, when there was an exception when adding a file with drag and drop, the same message was displayed regardless of the exception thrown.

With this changes we get the message of the exception to show the correct message.

Steps to reproduce the problem:
1. Set system parameter dms.binary_max_size to 1
2. Drag a file larger than 1 MB into any folder

You will see the error "A file with the same name already exists" instead of "The maximum upload size is 1 MB."

cc @Tecnativa TT49411

ping @chienandalu @victoralmau 