### PR TITLE
[16.0][FIX] dms: Fix share action

### DIFF
--- a/dms/__manifest__.py
+++ b/dms/__manifest__.py
@@ -30,6 +30,7 @@
         "views/res_config_settings.xml",
         "views/dms_portal_templates.xml",
         "wizards/wizard_dms_file_move_views.xml",
+        "wizards/wizard_dms_share_views.xml",
     ],
     "assets": {
         "mail.assets_messaging": [

--- a/dms/security/ir.model.access.csv
+++ b/dms/security/ir.model.access.csv
@@ -24,3 +24,4 @@ access_security_access_groups_user,access_security_access_groups_user,model_dms_
 access_security_access_groups_dms_user,access_security_access_groups_dms_user,model_dms_access_group,group_dms_user,1,1,1,1
 
 access_wizard_dms_file_move,access_wizard_dms_file_move,model_wizard_dms_file_move,group_dms_user,1,1,1,1
+access_wizard_dms_share,access_wizard_dms_share,model_wizard_dms_share,group_dms_manager,1,1,1,0

--- a/dms/tests/test_file.py
+++ b/dms/tests/test_file.py
@@ -8,6 +8,7 @@ import base64
 from odoo.exceptions import UserError
 from odoo.tests import new_test_user
 from odoo.tests.common import users
+from odoo.tools import mute_logger
 
 from .common import StorageFileBaseCase
 
@@ -48,6 +49,7 @@ class FileFilestoreTestCase(StorageFileBaseCase):
         self.assertIn(self.sub_directory_x.id, dms_directories.ids)
 
     @users("dms-manager", "dms-user")
+    @mute_logger("odoo.models.unlink")
     def test_content_file(self):
         lobject_file = self.create_file(directory=self.directory)
         self.assertTrue(lobject_file.content)

--- a/dms/views/directory.xml
+++ b/dms/views/directory.xml
@@ -402,12 +402,6 @@
         <field name="arch" type="xml">
             <form>
                 <header>
-                    <button
-                        name="%(portal.portal_share_action)d"
-                        string="Share"
-                        type="action"
-                        class="oe_highlight oe_read_only"
-                    />
                 </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -378,12 +378,6 @@
                         string="Unlock"
                         attrs="{'invisible':['|',('is_locked', '=', False),('is_lock_editor', '=', False)]}"
                     />
-                    <button
-                        name="%(portal.portal_share_action)d"
-                        string="Share"
-                        type="action"
-                        class="oe_highlight oe_read_only"
-                    />
                 </header>
                 <sheet>
                     <widget

--- a/dms/wizards/__init__.py
+++ b/dms/wizards/__init__.py
@@ -1,1 +1,2 @@
 from . import wizard_dms_file_move
+from . import wizard_dms_share

--- a/dms/wizards/wizard_dms_share.py
+++ b/dms/wizards/wizard_dms_share.py
@@ -1,0 +1,19 @@
+# Copyright 2024 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class WizardDmsShare(models.TransientModel):
+    _name = "wizard.dms.share"
+    _inherit = "portal.share"
+    _description = "Wizard for sharing DMS records"
+
+    @api.model
+    def _selection_target_model(self):
+        return [
+            (model.model, model.name)
+            for model in self.env["ir.model"]
+            .sudo()
+            .search([("model", "in", ("dms.directory", "dms.file"))])
+        ]

--- a/dms/wizards/wizard_dms_share_views.xml
+++ b/dms/wizards/wizard_dms_share_views.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="wizard_dms_share_form" model="ir.ui.view">
+        <field name="name">wizard.dms.share.form</field>
+        <field name="model">wizard.dms.share</field>
+        <field name="inherit_id" ref="portal.portal_share_wizard" />
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <field name="res_model" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+        </field>
+    </record>
+    <record id="wizard_dms_directory_share_action" model="ir.actions.act_window">
+        <field name="name">Share</field>
+        <field name="res_model">wizard.dms.share</field>
+        <field name="binding_model_id" ref="model_dms_directory" />
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+    <record id="wizard_dms_file_share_action" model="ir.actions.act_window">
+        <field name="name">Share</field>
+        <field name="res_model">wizard.dms.share</field>
+        <field name="binding_model_id" ref="model_dms_file" />
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+</odoo>


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/dms/pull/345

Allow share (directories and files) without 'Contact creation' permission

Extra changes: Replace Share buttons with actions

Steps to reproduce:
 - Go to Settings > Users & Companies > Users and create a user only with Documents > Manager permission. (User must not have the Extra Rights > Contact Creation permission).
 - Go to Documents and go into a directory form view and click on "Share" button.
 - An access error is displayed

Fixes https://github.com/OCA/dms/issues/343

Please @pedrobaeza can you review it?

@Tecnativa