### PR TITLE
[16.0][FIX] dms_field: Use own service instead of using dialog service of component

### DIFF
--- a/dms_field/static/src/views/dms_list/dms_list_renderer.esm.js
+++ b/dms_field/static/src/views/dms_list/dms_list_renderer.esm.js
@@ -17,6 +17,7 @@ export class DmsListRenderer extends Component {
         this.nodeSelectedState = useState({data: {}});
         this.messaging = useService("messaging");
         this.notification = useService("notification");
+        this.dialog = useService("dialog");
         this.dragState = useState({
             showDragZone: false,
         });
@@ -382,7 +383,7 @@ export class DmsListRenderer extends Component {
         var context = {
             default_parent_directory_id: node.data.data.id,
         };
-        Component.env.services.dialog.add(FormViewDialog, {
+        this.dialog.add(FormViewDialog, {
             resModel: "dms.directory",
             context: context,
             title: _lt("Add Directory: ") + node.data.data.name,
@@ -415,7 +416,7 @@ export class DmsListRenderer extends Component {
         var context = {
             default_directory_id: node.data.data.id,
         };
-        Component.env.services.dialog.add(FormViewDialog, {
+        this.dialog.add(FormViewDialog, {
             resModel: "dms.file",
             context: context,
             title: _lt("Add File: ") + node.data.data.name,
@@ -451,7 +452,7 @@ export class DmsListRenderer extends Component {
         });
     }
     onDMSOpenRecord(node) {
-        Component.env.services.dialog.add(FormViewDialog, {
+        this.dialog.add(FormViewDialog, {
             resModel: node.data.resModel,
             title: _lt("Open: ") + node.data.data.name,
             resId: node.data.data.id,


### PR DESCRIPTION
cc @Tecnativa TT48507

This commit solves the problems reported on https://github.com/OCA/dms/issues/347

Steps to reproduce the problem:

1. Go to Documents > Documents
2. Select a file and press on eye button to preview it
3. Close preview
4. Select a folder
5. Press on buttons Create a folder, Create a file or Open the folder

An error about dialog.add is not a function will be thrown

ping @pedrobaeza @victoralmau @hitrosol 