### PR TITLE
[15.0][IMP+FIX] dms: Improve performance + Avoid non-existing record access error

### DIFF
--- a/dms/models/dms_security_mixin.py
+++ b/dms/models/dms_security_mixin.py
@@ -132,8 +132,11 @@ class DmsSecurityMixin(models.AbstractModel):
                 continue
             domains.append([("res_model", "=", model._name), ("res_id", "=", False)])
             # Check record access in batch too
-            group_ids = [i for i in group["res_id"] if i]  # Hack to remove None res_id
-            related_ok = model.browse(group_ids)._filter_access_rules_python(operation)
+            res_ids = [i for i in group["res_id"] if i]  # Hack to remove None res_id
+            # Apply exists to skip records that do not exist. (e.g. a res.partner deleted
+            # by database).
+            model_records = model.browse(res_ids).exists()
+            related_ok = model_records._filter_access_rules_python(operation)
             if not related_ok:
                 continue
             domains.append(

--- a/dms/models/storage.py
+++ b/dms/models/storage.py
@@ -145,3 +145,9 @@ class Storage(models.Model):
     def _compute_count_storage_files(self):
         for record in self:
             record.count_storage_files = len(record.storage_file_ids)
+
+    def write(self, values):
+        res = super().write(values)
+        if "model_ids" in values:
+            self.env["ir.attachment"].clear_caches()
+        return res

--- a/dms/tests/test_storage_attachment.py
+++ b/dms/tests/test_storage_attachment.py
@@ -30,6 +30,19 @@ class StorageAttachmentTestCase(StorageAttachmentBaseCase):
         self.assertFalse(directory.exists())
 
     @users("dms-manager")
+    def test_storage_attachment_record_db_unlink(self):
+        self._create_attachment("demo.txt")
+        self.assertTrue(
+            self.storage.storage_file_ids.filtered(lambda x: x.name == "demo.txt")
+        )
+        directory = self._get_partner_directory()
+        self.assertEqual(directory.res_model, self.partner._name)
+        self.assertEqual(directory.res_id, self.partner.id)
+        directory.res_id = 0  # Trick to reference a non-existing record
+        directories = self.env["dms.directory"].search([])
+        self.assertNotIn(directory.id, directories.ids)
+
+    @users("dms-manager")
     def test_storage_attachment_misc(self):
         attachment = self._create_attachment("demo.txt")
         root_directory = self.storage.root_directory_ids.filtered(


### PR DESCRIPTION
Improve performance + Avoid non-existing record access error

Changes done:
- [x] Improve `_dms_operations()` method to do nothing if the model is not one of those used in `dms.storage`.
- [x] Avoid access error with `.browse()` if we access a non-existing record (for example, deleted by database).

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT50231