### PR TITLE
[16.0][FIX] dms_field: Show the correct image (same as kanban view) of the files in the right panel

### DIFF
--- a/dms_field/static/src/views/dms_list/dms_list_controller.esm.js
+++ b/dms_field/static/src/views/dms_list/dms_list_controller.esm.js
@@ -315,6 +315,7 @@ export const DMSListControllerObject = {
                 file.permission_write && (!file.is_locked || file.is_lock_editor),
             perm_unlink:
                 file.permission_unlink && (!file.is_locked || file.is_lock_editor),
+            icon_url: file.icon_url,
         });
         var dt = this.makeDataPoint({
             data: data,
@@ -413,6 +414,7 @@ export const DMSListControllerObject = {
             "permission_create",
             "permission_write",
             "permission_unlink",
+            "icon_url",
             "name",
             "mimetype",
             "directory_id",

--- a/dms_field/static/src/views/dms_list/dms_list_renderer.xml
+++ b/dms_field/static/src/views/dms_list/dms_list_renderer.xml
@@ -58,7 +58,7 @@
                             >
                                 <img
                                     class="h-100 w-100"
-                                    t-attf-src="/web/image/dms.file/{{nodeSelectedState.data.data.id}}/image_256/256x256?crop=1"
+                                    t-att-src="nodeSelectedState.data.data.icon_url"
                                 />
                             </a>
                         </div>


### PR DESCRIPTION
Show the correct image (same as kanban view) of the files in the right panel

**Before**
![antes](https://github.com/user-attachments/assets/c3cf7c5c-aeab-41b8-836b-3b2e8c2cb25a)

**After**
![despues](https://github.com/user-attachments/assets/769bf4e5-d690-412b-8617-8f97762aec95)

Fixes https://github.com/OCA/dms/issues/351

Please @CarlosRoca13 and @pedrobaeza can you review it?

@Tecnativa