### PR TITLE
[16.0][FIX] dms_field: Incompatibility with web_responsive

### DIFF
--- a/dms_field/static/src/views/dms_list/dms_list.scss
+++ b/dms_field/static/src/views/dms_list/dms_list.scss
@@ -1,0 +1,16 @@
+// This code is necessary to avoid an incompatibility with the definition
+// .o_field_widget input, .o_field_widget textarea {color: inherit} added by
+// web_responsive. This causes the text to appear white when editing the name of
+// the selected file/directory on field mode (Example: field added on hr.employee by
+// hr_dms_field), making it impossible to see the content. It is necessary to maintain
+// it in version 16.0, and if migrating to higher versions, check if it remains
+// necessary.
+.jstree-proton .jstree-clicked {
+    color: #000000 !important;
+    i {
+        color: #ffffff;
+    }
+}
+.jstree-proton a.jstree-clicked {
+    color: #ffffff !important;
+}


### PR DESCRIPTION
When we edit the name of a file or directory while positioned in a field, like the one added by hr_dms_field with web_responsive installed, the input text appears white, making it impossible to edit.
![white](https://github.com/user-attachments/assets/d11dd47f-7582-46c9-a484-404f067ac7aa)

With these changes, the text appears black and can be edited normally.
![black](https://github.com/user-attachments/assets/37dfc92b-21ed-4e2f-8364-9a4621f1a3f3)

cc @Tecnativa TT50329

ping @victoralmau @pedrobaeza 