### PR TITLE
[16.0][FIX] dms_field: Avoid access error in dms.access.groups linked to an other company's records

### DIFF
--- a/dms_field/models/dms_access_group.py
+++ b/dms_field/models/dms_access_group.py
@@ -12,6 +12,12 @@ class DmsAccessGroups(models.Model):
         selection="_selection_reference_value",
         string="DMS field reference",
     )
+    company_id = fields.Many2one(
+        compute="_compute_company_id",
+        comodel_name="res.company",
+        string="Company",
+        store=True,
+    )
 
     @api.model
     def _selection_reference_value(self):
@@ -21,6 +27,16 @@ class DmsAccessGroups(models.Model):
             .search([("transient", "=", False)], order="name asc")
         )
         return [(model.model, model.name) for model in models]
+
+    @api.depends("dms_field_ref")
+    def _compute_company_id(self):
+        self.company_id = False
+        for item in self.filtered("dms_field_ref"):
+            item.company_id = (
+                item.dms_field_ref.company_id
+                if "company_id" in item.dms_field_ref._fields
+                else False
+            )
 
     def _get_item_from_dms_field_ref(self, record):
         return self.env["dms.access.group"].search(

--- a/dms_field/security/security.xml
+++ b/dms_field/security/security.xml
@@ -8,4 +8,12 @@
             name="domain_force"
         >['|',('company_id','=',False),('company_id','in',company_ids)]</field>
     </record>
+    <record id="rule_multi_company_dms_access_group" model="ir.rule">
+        <field name="name">DMS Access Group multi-company</field>
+        <field name="model_id" ref="model_dms_access_group" />
+        <field name="global" eval="True" />
+        <field
+            name="domain_force"
+        >['|',('company_id','=',False),('company_id','in',company_ids)]</field>
+    </record>
 </odoo>

--- a/dms_field/tests/test_dms_field.py
+++ b/dms_field/tests/test_dms_field.py
@@ -111,6 +111,27 @@ class TestDmsField(TransactionCase):
         with self.assertRaises(UserError):
             group.copy({"name": "Test 2"})
 
+    def test_dms_access_group_company_dms_field_ref_01(self):
+        self.partner.company_id = False
+        group = self.env["dms.access.group"].create(
+            {
+                "name": "Test 1",
+                "dms_field_ref": "%s,%s" % (self.partner._name, self.partner.id),
+            }
+        )
+        self.assertFalse(group.company_id)
+
+    def test_dms_access_group_company_dms_field_ref_02(self):
+        self.company = self.env.company
+        self.partner.company_id = self.company
+        group = self.env["dms.access.group"].create(
+            {
+                "name": "Test 1",
+                "dms_field_ref": "%s,%s" % (self.partner._name, self.partner.id),
+            }
+        )
+        self.assertEqual(group.company_id, self.company)
+
     def test_template_directory(self):
         self.assertTrue(self.template.dms_directory_ids)
         self.assertIn(


### PR DESCRIPTION
Avoid access error in `dms.access.groups` linked to an other company's records

Please @pedrobaeza and  @carolinafernandez-tecnativa can you review it?

@Tecnativa TT50390