### PR TITLE
[15.0][FIX] dms_field: Show the correct image (same as kanban view) of the files in the right panel

### DIFF
--- a/dms_field/static/src/js/base/dms_tree_controller.js
+++ b/dms_field/static/src/js/base/dms_tree_controller.js
@@ -218,6 +218,7 @@ odoo.define("dms.DmsTreeController", function (require) {
                     "permission_create",
                     "permission_write",
                     "permission_unlink",
+                    "icon_url",
                     "name",
                     "mimetype",
                     "directory_id",
@@ -463,6 +464,7 @@ odoo.define("dms.DmsTreeController", function (require) {
                     file.permission_write && (!file.is_locked || file.is_lock_editor),
                 perm_unlink:
                     file.permission_unlink && (!file.is_locked || file.is_lock_editor),
+                icon_url: file.icon_url,
             });
             var dt = this._makeDataPoint({
                 data: data,

--- a/dms_field/static/src/xml/preview.xml
+++ b/dms_field/static/src/xml/preview.xml
@@ -21,7 +21,7 @@
                             >
                                 <img
                                     class="h-100 w-100"
-                                    t-attf-src="/web/image/dms.file/{{dms_object.data.id}}/image_256/256x256?crop=1"
+                                    t-att-src="dms_object.data.icon_url"
                                 />
                             </a>
                         </div>


### PR DESCRIPTION
Backport from 16.0: https://github.com/OCA/dms/pull/352

Show the correct image (same as kanban view) of the files in the right panel

**Before**
![antes](https://github.com/user-attachments/assets/c3cf7c5c-aeab-41b8-836b-3b2e8c2cb25a)

**After**
![despues](https://github.com/user-attachments/assets/769bf4e5-d690-412b-8617-8f97762aec95)

Fixes https://github.com/OCA/dms/issues/351

Please @CarlosRoca13 and @pedrobaeza can you review it?

@Tecnativa