### PR TITLE
[14.0][FIX] dms_field: Show the correct image (same as kanban view) of the files in the right panel

### DIFF
--- a/dms_field/static/src/js/base/dms_tree_controller.js
+++ b/dms_field/static/src/js/base/dms_tree_controller.js
@@ -138,6 +138,7 @@ odoo.define("dms.DmsTreeController", function (require) {
                         "count_files",
                         "name",
                         "parent_id",
+                        "icon_url",
                         "__last_update",
                     ]),
                     domain: this._buildDMSDomain(
@@ -165,6 +166,7 @@ odoo.define("dms.DmsTreeController", function (require) {
                     "count_files",
                     "name",
                     "parent_id",
+                    "icon_url",
                     "__last_update",
                 ]),
                 domain: this._buildDMSDomain(
@@ -187,6 +189,7 @@ odoo.define("dms.DmsTreeController", function (require) {
                     "permission_create",
                     "permission_write",
                     "permission_unlink",
+                    "icon_url",
                     "name",
                     "mimetype",
                     "directory_id",
@@ -383,13 +386,7 @@ odoo.define("dms.DmsTreeController", function (require) {
                 perm_create: directory.permission_create,
                 perm_write: directory.permission_write,
                 perm_unlink: directory.permission_unlink,
-
-                thumbnail_link: session.url("/web/image", {
-                    model: "dms.directory",
-                    field: "thumbnail_medium",
-                    unique: directory.__last_update.replace(/[^0-9]/g, ""),
-                    id: directory.id,
-                }),
+                icon_url: directory.icon_url,
             });
             if (
                 storage &&
@@ -434,12 +431,7 @@ odoo.define("dms.DmsTreeController", function (require) {
                     file.permission_write && (!file.is_locked || file.is_lock_editor),
                 perm_unlink:
                     file.permission_unlink && (!file.is_locked || file.is_lock_editor),
-                thumbnail_link: session.url("/web/image", {
-                    model: "dms.file",
-                    field: "thumbnail_medium",
-                    unique: file.__last_update.replace(/[^0-9]/g, ""),
-                    id: file.id,
-                }),
+                icon_url: file.icon_url,
             });
             var dt = this._makeDataPoint({
                 data: data,

--- a/dms_field/static/src/xml/preview.xml
+++ b/dms_field/static/src/xml/preview.xml
@@ -11,9 +11,20 @@
                 <div class="o_preview_directory_icon" align="center">
                     <div>
                         <img
+                            t-if="dms_object.model === 'dms.directory'"
                             class="h-100 w-100"
-                            t-att-src="dms_object.data.thumbnail_link"
+                            t-att-src="dms_object.data.icon_url"
                         />
+                        <a
+                            t-if="dms_object.model === 'dms.file'"
+                            class="o_preview_file"
+                            t-att-data-id="dms_object.id"
+                        >
+                            <img
+                                class="h-100 w-100"
+                                t-att-src="dms_object.data.icon_url"
+                            />
+                        </a>
                     </div>
                     <div>
                         <button


### PR DESCRIPTION
Backport from 15.0: https://github.com/OCA/dms/pull/356

Show the correct image (same as kanban view) of the files in the right panel

**Before**
![antes](https://github.com/user-attachments/assets/c3cf7c5c-aeab-41b8-836b-3b2e8c2cb25a)

**After**
![despues](https://github.com/user-attachments/assets/769bf4e5-d690-412b-8617-8f97762aec95)

Fixes https://github.com/OCA/dms/issues/351

Please @CarlosRoca13 and @pedrobaeza can you review it?

@Tecnativa