### PR TITLE
[16.0][IMP] dms_auto_classification + dms_field_auto_classification: Remove warning by several names with the same label

### DIFF
--- a/dms_auto_classification/wizards/wizard_dms_classification.py
+++ b/dms_auto_classification/wizards/wizard_dms_classification.py
@@ -137,7 +137,7 @@ class WizardDmsClassificationDetail(models.TransientModel):
         string="File name",
     )
     data_file = fields.Binary(
-        string="File",
+        string="File content",
         required=True,
     )
     directory_id = fields.Many2one(

--- a/dms_field_auto_classification/models/dms_classification_template.py
+++ b/dms_field_auto_classification/models/dms_classification_template.py
@@ -10,7 +10,9 @@ class DmsClassificationTemplate(models.Model):
     model_id = fields.Many2one(
         comodel_name="ir.model", string="Model", domain=[("transient", "=", False)]
     )
-    model = fields.Char(compute="_compute_model", compute_sudo=True)
+    model = fields.Char(
+        compute="_compute_model", string="Model name", compute_sudo=True
+    )
     detail_ids = fields.One2many(
         string="Details",
         comodel_name="dms.classification.template.detail",


### PR DESCRIPTION
Remove warning by several names with the same label

`WARNING devel odoo.addons.base.models.ir_model: Two fields (file_id, data_file) of wizard.dms.classification.detail() have the same label: File. [Modules: dms_auto_classification and dms_auto_classification]`

`WARNING devel odoo.addons.base.models.ir_model: Two fields (model, model_id) of dms.classification.template() have the same label: Model. [Modules: dms_field_auto_classification and dms_field_auto_classification]`

Please @pedrobaeza can you review it?

@Tecnativa TT51051