### PR TITLE
[16.0][FIX] dms_field: Test compatibility

### DIFF
--- a/account_dms_field/tests/test_account_dms_field.py
+++ b/account_dms_field/tests/test_account_dms_field.py
@@ -1,19 +1,21 @@
-from odoo.addons.base.tests.common import TransactionCase
+from odoo.addons.base.tests.common import BaseCommon
 
 
-class TestAccountDmsField(TransactionCase):
-    def setUp(self):
-        super(TestAccountDmsField, self).setUp()
-        self.template = self.env.ref("account_dms_field.field_template_account")
-        self.storage = self.template.storage_id
-        self.access_group = self.template.group_ids
-        self.account_model = self.env["account.move"]
-        self.partner = self.env.ref("base.res_partner_12")
-        self.test_directory = self.env["dms.directory"].create(
+class TestAccountDmsField(BaseCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, test_dms_field=True))
+        cls.template = cls.env.ref("account_dms_field.field_template_account")
+        cls.storage = cls.template.storage_id
+        cls.access_group = cls.template.group_ids
+        cls.account_model = cls.env["account.move"]
+        cls.partner = cls.env.ref("base.res_partner_12")
+        cls.test_directory = cls.env["dms.directory"].create(
             {
                 "name": "Test Directory",
-                "parent_id": self.template.dms_directory_ids[0].id,
-                "storage_id": self.template.storage_id.id,
+                "parent_id": cls.template.dms_directory_ids[0].id,
+                "storage_id": cls.template.storage_id.id,
             }
         )
 

--- a/dms_field/tests/test_dms_field.py
+++ b/dms_field/tests/test_dms_field.py
@@ -4,24 +4,17 @@
 
 from odoo import fields
 from odoo.exceptions import UserError, ValidationError
-from odoo.tests import TransactionCase, new_test_user
+from odoo.tests import new_test_user
 from odoo.tools import mute_logger
 
+from odoo.addons.base.tests.common import BaseCommon
 
-class TestDmsField(TransactionCase):
+
+class TestDmsField(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env = cls.env(
-            context=dict(
-                cls.env.context,
-                mail_create_nolog=True,
-                mail_create_nosubscribe=True,
-                mail_notrack=True,
-                no_reset_password=True,
-                tracking_disable=True,
-            )
-        )
+        cls.env = cls.env(context=dict(cls.env.context, test_dms_field=True))
         cls.user_a = new_test_user(cls.env, login="test-user-a")
         cls.group = cls.env["res.groups"].create(
             {"name": "Test group", "users": [(4, cls.user_a.id)]}

--- a/dms_field_auto_classification/tests/test_dms_field_auto_classification.py
+++ b/dms_field_auto_classification/tests/test_dms_field_auto_classification.py
@@ -14,6 +14,7 @@ class TestDmsFieldAutoClassification(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, test_dms_field=True))
         cls.template = cls.env.ref(
             "dms_field_auto_classification.dms_classification_template_partners"
         )

--- a/hr_dms_field/tests/test_hr_dms_field.py
+++ b/hr_dms_field/tests/test_hr_dms_field.py
@@ -11,6 +11,7 @@ class TestHrDmsField(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, test_dms_field=True))
         cls.template = cls.env.ref("hr_dms_field.field_template_employee")
         cls.storage = cls.template.storage_id
         cls.access_group = cls.template.group_ids


### PR DESCRIPTION
Test compatibility

We need to avoid applying a template except when testing functionality with `dms_field*` modules to avoid the error that a directory with the same name already exists (example: create partner).

Related to https://github.com/OCA/dms/pull/378

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa