### PR TITLE
[16.0][FIX] dms_field: Apply sudo() to apply the corresponding process even if the user does not have access to the linked directory.

### DIFF
--- a/dms_field/models/dms_field_mixin.py
+++ b/dms_field/models/dms_field_mixin.py
@@ -56,7 +56,8 @@ class DMSFieldMixin(models.AbstractModel):
         (name and explicit_user_ids).
         """
         res = super().write(vals)
-        for item in self.filtered("dms_directory_ids"):
+        # Apply sudo() in case the user does not have access to the directory
+        for item in self.sudo().filtered("dms_directory_ids"):
             if "user_id" in vals:
                 template = self.env["dms.field.template"]._get_template_from_model(
                     item._name
@@ -69,7 +70,8 @@ class DMSFieldMixin(models.AbstractModel):
         """When deleting a record, we also delete the linked directories and the
         auto-generated access group.
         """
-        for record in self.filtered("dms_directory_ids"):
+        # Apply sudo() in case the user does not have access to the directory
+        for record in self.sudo().filtered("dms_directory_ids"):
             group = (
                 self.env["dms.access.group"].sudo()._get_item_from_dms_field_ref(record)
             )

--- a/hr_dms_field/tests/test_hr_dms_field.py
+++ b/hr_dms_field/tests/test_hr_dms_field.py
@@ -64,6 +64,31 @@ class TestHrDmsField(BaseCommon):
         group_custom = employee.dms_directory_ids.group_ids.filtered("dms_field_ref")
         self.assertIn(self.user, group_custom.explicit_user_ids)
 
+    def test_employee_write_custom(self):
+        read_access_hr_employee_group = self.env.ref(
+            "hr_dms_field.read_access_hr_employee_group"
+        )
+        read_access_hr_employee_group.write(
+            {
+                "group_ids": [(5, 0)],
+                "explicit_user_ids": [(6, 0, self.env.ref("base.user_admin").ids)],
+            }
+        )
+        employee = self.employee_model.create({"name": "Test employee"})
+        employee.invalidate_recordset()
+        directory = employee.dms_directory_ids
+        self.assertEqual(len(directory), 1)
+        directory_0 = employee.dms_directory_ids[0]
+        group_custom = directory_0.group_ids.filtered("dms_field_ref")
+        self.assertFalse(group_custom.explicit_user_ids)
+        # Use the demo user to modify the employee and link the user, it does not
+        # have access to the directory.
+        demo = self.env.ref("base.user_demo")
+        employee = employee.with_user(demo)
+        employee.invalidate_recordset()
+        employee.write({"user_id": self.user.id})
+        self.assertIn(self.user, group_custom.explicit_user_ids)
+
     @mute_logger("odoo.models.unlink")
     def test_employee_full_process(self):
         employee = self.employee_model.create(


### PR DESCRIPTION
Apply `sudo()` to apply the corresponding process even if the user does not have access to the linked directory.

Example use case:
- Define a dms template with an access group and set only Admin as the explicit user (without groups).
- Create a "Test employee" employee.
- Modify the employee with Marc Demo and link him a new user (test-user)
- The auto-generated access group of test-employee will have test-user defined as explicit user.

Please @chienandalu and @pedrobaeza can you review it?

@Tecnativa TT55368