### PR TITLE
[FIX] dms: fix access rules for better security

### DIFF
--- a/dms/README.rst
+++ b/dms/README.rst
@@ -148,6 +148,9 @@ and their files. Another possibility is to click on "Share" button
 inside a directory or a file for obtaining a tokenized link for single
 access to that resource, no matter if logged or not.
 
+For any file if you add the portal user or the internal user to
+followers mixin, they can read that file.
+
 Known issues / Roadmap
 ======================
 

--- a/dms/__manifest__.py
+++ b/dms/__manifest__.py
@@ -28,6 +28,9 @@
         "template/portal.xml",
         # Data
         "data/onboarding_data.xml",
+        # Wizard
+        "wizards/wizard_dms_file_move_views.xml",
+        "wizards/wizard_dms_share_views.xml",
         # Views
         "views/dms_tag.xml",
         "views/dms_category.xml",
@@ -37,9 +40,6 @@
         "views/dms_access_groups_views.xml",
         "views/res_config_settings.xml",
         "views/menu.xml",
-        # Wizard
-        "wizards/wizard_dms_file_move_views.xml",
-        "wizards/wizard_dms_share_views.xml",
     ],
     "assets": {
         "web.assets_backend": [

--- a/dms/controllers/portal.py
+++ b/dms/controllers/portal.py
@@ -177,6 +177,11 @@ class CustomerPortal(CustomerPortal):
         file_domain = [
             ("is_hidden", "=", False),
             ("directory_id", "=", dms_directory_id),
+            (
+                "message_partner_ids",
+                "child_of",
+                [request.env.user.commercial_partner_id.id],
+            ),
         ]
         # search
         if search and search_in == "name":
@@ -206,7 +211,15 @@ class CustomerPortal(CustomerPortal):
         :rtype: tuple[odoo.model.dms_directory, bool|odoo.model.dms_directory]
         """
         # domain
-        domain = [("is_hidden", "=", False), ("parent_id", "=", dms_directory_id)]
+        domain = [
+            ("is_hidden", "=", False),
+            ("parent_id", "=", dms_directory_id),
+            (
+                "file_ids.message_partner_ids",
+                "child_of",
+                [request.env.user.commercial_partner_id.id],
+            ),
+        ]
         # search
         if search and search_in:
             domain.append(("name", "ilike", search))

--- a/dms/readme/USAGE.md
+++ b/dms/readme/USAGE.md
@@ -9,3 +9,5 @@ group in directories, so they will see in the portal such directories
 and their files. Another possibility is to click on "Share" button
 inside a directory or a file for obtaining a tokenized link for single
 access to that resource, no matter if logged or not.
+
+For any file if you add the portal user or the internal user to followers mixin, they can read that file.

--- a/dms/security/ir.model.access.csv
+++ b/dms/security/ir.model.access.csv
@@ -8,17 +8,14 @@ access_dms_storage_portal,dms_storage_portal,model_dms_storage,base.group_portal
 access_dms_storage_user,dms_storage_user,model_dms_storage,group_dms_user,1,0,0,0
 access_dms_storage_manager,dms_storage_manager,model_dms_storage,group_dms_manager,1,1,1,1
 
-access_dms_directory_public,dms_directory_public,model_dms_directory,base.group_public,1,0,0,0
 access_dms_directory_portal,dms_directory_portal,model_dms_directory,base.group_portal,1,0,0,0
 access_dms_directory_base_user,dms_directory_base_user,model_dms_directory,base.group_user,1,0,0,0
 access_dms_directory_user,dms_directory_user,model_dms_directory,group_dms_user,1,1,1,1
 
-access_dms_file_public,dms_file_public,model_dms_file,base.group_public,1,0,0,0
 access_dms_file_portal,dms_file_portal,model_dms_file,base.group_portal,1,0,0,0
 access_dms_file_base_user,dms_file_base_user,model_dms_file,base.group_user,1,0,0,0
 access_dms_file_user,dms_file_user,model_dms_file,group_dms_user,1,1,1,1
 
-access_dms_access_group_public,access_dms_access_group_public,model_dms_access_group,base.group_public,1,0,0,0
 access_dms_access_group_portal,access_dms_access_group_portal,model_dms_access_group,base.group_portal,1,0,0,0
 access_security_access_groups_user,access_security_access_groups_user,model_dms_access_group,base.group_user,1,0,0,0
 access_security_access_groups_dms_user,access_security_access_groups_dms_user,model_dms_access_group,group_dms_user,1,1,1,1

--- a/dms/security/ir.model.access.csv
+++ b/dms/security/ir.model.access.csv
@@ -1,6 +1,9 @@
 id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink
 
+access_dms_tag_base_user,dms_tag_base_user,model_dms_tag,base.group_user,1,0,0,0
 access_dms_tag_user,dms_tag_user,model_dms_tag,group_dms_user,1,1,1,1
+
+access_dms_category_base_user,dms_category_base_user,model_dms_category,base.group_user,1,0,0,0
 access_dms_category_user,dms_category_user,model_dms_category,group_dms_user,1,1,1,1
 
 access_dms_storage_base_user,dms_storage_base_user,model_dms_storage,base.group_user,1,0,0,0

--- a/dms/security/security.xml
+++ b/dms/security/security.xml
@@ -132,9 +132,29 @@
         <field name="perm_unlink" eval="1" />
         <field name="domain_force">[('is_hidden', '=', True)]</field>
     </record>
+    <record id="user_rule_category_computed_read" model="ir.rule">
+        <field name="name">DMS User Categories</field>
+        <field name="model_id" ref="model_dms_category" />
+        <field name="domain_force">[(1 ,'=', 1)]</field>
+        <field name="groups" eval="[Command.link(ref('dms.group_dms_user'))]" />
+        <field name="perm_unlink" eval="True" />
+        <field name="perm_write" eval="True" />
+        <field name="perm_read" eval="True" />
+        <field name="perm_create" eval="True" />
+    </record>
+    <record id="user_rule_tag_computed_read" model="ir.rule">
+        <field name="name">DMS User Tags</field>
+        <field name="model_id" ref="model_dms_tag" />
+        <field name="domain_force">[(1 ,'=', 1)]</field>
+        <field name="groups" eval="[Command.link(ref('dms.group_dms_user'))]" />
+        <field name="perm_unlink" eval="True" />
+        <field name="perm_write" eval="True" />
+        <field name="perm_read" eval="True" />
+        <field name="perm_create" eval="True" />
+    </record>
     <!-- Portal/Base Users Access Rules -->
     <record id="portal_rule_directory_computed_read" model="ir.rule">
-        <field name="name">Portal Personal Directories Read</field>
+        <field name="name">Portal/Base User Following Directories Read</field>
         <field name="model_id" ref="model_dms_directory" />
         <field
             name="domain_force"
@@ -150,7 +170,7 @@
     </record>
     <!-- Portal/Base Users Access Rules -->
     <record id="portal_rule_file_computed_read" model="ir.rule">
-        <field name="name">Portal Personal Files Read</field>
+        <field name="name">Portal/Base User Following Files Read</field>
         <field name="model_id" ref="model_dms_file" />
         <field name="global" eval="False" />
         <field
@@ -160,6 +180,37 @@
             name="groups"
             eval="[Command.link(ref('base.group_portal')), Command.link(ref('base.group_user'))]"
         />
+        <field name="perm_unlink" eval="False" />
+        <field name="perm_write" eval="False" />
+        <field name="perm_read" eval="True" />
+        <field name="perm_create" eval="False" />
+    </record>
+    <!-- Base Users Access Rules -->
+    <record id="base_user_rule_category_computed_read" model="ir.rule">
+        <field name="name">Base User Following Categories Read</field>
+        <field name="model_id" ref="model_dms_category" />
+        <field name="global" eval="False" />
+        <field
+            name="domain_force"
+        >[('file_ids.message_partner_ids','child_of',[user.commercial_partner_id.id])]</field>
+        <field name="groups" eval="[Command.link(ref('base.group_user'))]" />
+        <field name="perm_unlink" eval="False" />
+        <field name="perm_write" eval="False" />
+        <field name="perm_read" eval="True" />
+        <field name="perm_create" eval="False" />
+    </record>
+    <!-- Base Users Access Rules -->
+    <record id="base_user_rule_tag_computed_read" model="ir.rule">
+        <field name="name">Base User Following Tags Read</field>
+        <field name="model_id" ref="model_dms_tag" />
+        <field name="global" eval="False" />
+        <field name="domain_force">
+            ['|',
+                ('file_ids.message_partner_ids', 'child_of', [user.commercial_partner_id.id]),
+                ('directory_ids.file_ids.message_partner_ids', 'child_of', [user.commercial_partner_id.id])
+            ]
+        </field>
+        <field name="groups" eval="[Command.link(ref('base.group_user'))]" />
         <field name="perm_unlink" eval="False" />
         <field name="perm_write" eval="False" />
         <field name="perm_read" eval="True" />

--- a/dms/security/security.xml
+++ b/dms/security/security.xml
@@ -15,7 +15,7 @@
     <record id="group_dms_user" model="res.groups">
         <field name="name">User</field>
         <field name="category_id" ref="category_dms_security" />
-        <field name="implied_ids" eval="[(4, ref('base.group_user'))]" />
+        <field name="implied_ids" eval="[(4, ref('base.group_erp_manager'))]" />
     </record>
     <record id="group_dms_manager" model="res.groups">
         <field name="name">Manager</field>
@@ -29,7 +29,12 @@
     <record id="rule_multi_company_storage" model="ir.rule">
         <field name="name">DMS Storage multi-company</field>
         <field name="model_id" ref="model_dms_storage" />
-        <field name="global" eval="True" />
+        <field name="global" eval="False" />
+        <field name="groups" eval="[(4, ref('group_dms_user'))]" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_unlink" eval="0" />
         <field
             name="domain_force"
         >['|',('company_id','=',False),('company_id','in',company_ids)]</field>
@@ -37,7 +42,12 @@
     <record id="rule_multi_company_directory" model="ir.rule">
         <field name="name">DMS Directory multi-company</field>
         <field name="model_id" ref="model_dms_directory" />
-        <field name="global" eval="True" />
+        <field name="global" eval="False" />
+        <field name="groups" eval="[(4, ref('group_dms_user'))]" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_unlink" eval="0" />
         <field
             name="domain_force"
         >['|',('company_id','=',False),('company_id','in',company_ids)]</field>
@@ -45,7 +55,12 @@
     <record id="rule_multi_company_file" model="ir.rule">
         <field name="name">File multi-company</field>
         <field name="model_id" ref="model_dms_file" />
-        <field name="global" eval="True" />
+        <field name="global" eval="False" />
+        <field name="groups" eval="[(4, ref('group_dms_user'))]" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_unlink" eval="0" />
         <field
             name="domain_force"
         >['|',('company_id','=',False),('company_id','in',company_ids)]</field>
@@ -53,15 +68,25 @@
     <record id="rule_file_locked" model="ir.rule">
         <field name="name">Locked files are only modified by locker user.</field>
         <field name="model_id" ref="model_dms_file" />
-        <field name="groups" eval="[(4, ref('base.group_user'))]" />
+        <field name="groups" eval="[(4, ref('dms.group_dms_user'))]" />
         <field name="global" eval="True" />
         <field name="perm_read" eval="0" />
-        <field name="perm_create" eval="1" />
+        <field name="perm_create" eval="0" />
         <field name="perm_write" eval="1" />
         <field name="perm_unlink" eval="1" />
         <field
             name="domain_force"
         >['|', ('locked_by', '=', False), ('locked_by', '=', user.id)]</field>
+    </record>
+    <record id="rule_file_locked_exemption" model="ir.rule">
+        <field name="name">DMS Managers can edit and delete locked files.</field>
+        <field name="model_id" ref="model_dms_file" />
+        <field name="groups" eval="[(4, ref('group_dms_manager'))]" />
+        <field name="perm_read" eval="0" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_unlink" eval="1" />
+        <field name="domain_force">[(1 ,'=', 1)]</field>
     </record>
     <record id="rule_security_groups_user" model="ir.rule">
         <field name="name">DMS users can only edit and delete their own groups.</field>
@@ -107,85 +132,37 @@
         <field name="perm_unlink" eval="1" />
         <field name="domain_force">[('is_hidden', '=', True)]</field>
     </record>
-    <!-- These rules leverage computed permission management -->
-    <record id="rule_directory_computed_create" model="ir.rule">
-        <field name="name">Apply computed create permissions.</field>
+    <!-- Portal/Base Users Access Rules -->
+    <record id="portal_rule_directory_computed_read" model="ir.rule">
+        <field name="name">Portal Personal Directories Read</field>
         <field name="model_id" ref="model_dms_directory" />
-        <field name="global" eval="True" />
-        <field name="perm_read" eval="0" />
-        <field name="perm_create" eval="1" />
-        <field name="perm_write" eval="0" />
-        <field name="perm_unlink" eval="0" />
-        <field name="domain_force">[('permission_create', '=', user.id)]</field>
+        <field
+            name="domain_force"
+        >[('file_ids.message_partner_ids','child_of',[user.commercial_partner_id.id])]</field>
+        <field
+            name="groups"
+            eval="[Command.link(ref('base.group_portal')), Command.link(ref('base.group_user'))]"
+        />
+        <field name="perm_unlink" eval="False" />
+        <field name="perm_write" eval="False" />
+        <field name="perm_read" eval="True" />
+        <field name="perm_create" eval="False" />
     </record>
-    <record id="rule_directory_computed_read" model="ir.rule">
-        <field name="name">Apply computed read permissions.</field>
-        <field name="model_id" ref="model_dms_directory" />
-        <field name="global" eval="True" />
-        <field name="perm_read" eval="1" />
-        <field name="perm_create" eval="0" />
-        <field name="perm_write" eval="0" />
-        <field name="perm_unlink" eval="0" />
-        <field name="domain_force">[('permission_read', '=', user.id)]</field>
-    </record>
-    <record id="rule_directory_computed_unlink" model="ir.rule">
-        <field name="name">Apply computed unlink permissions.</field>
-        <field name="model_id" ref="model_dms_directory" />
-        <field name="global" eval="True" />
-        <field name="perm_read" eval="0" />
-        <field name="perm_create" eval="0" />
-        <field name="perm_write" eval="0" />
-        <field name="perm_unlink" eval="1" />
-        <field name="domain_force">[('permission_unlink', '=', user.id)]</field>
-    </record>
-    <record id="rule_directory_computed_write" model="ir.rule">
-        <field name="name">Apply computed write permissions.</field>
-        <field name="model_id" ref="model_dms_directory" />
-        <field name="global" eval="True" />
-        <field name="perm_read" eval="0" />
-        <field name="perm_create" eval="0" />
-        <field name="perm_write" eval="1" />
-        <field name="perm_unlink" eval="0" />
-        <field name="domain_force">[('permission_write', '=', user.id)]</field>
-    </record>
-    <record id="rule_file_computed_create" model="ir.rule">
-        <field name="name">Apply computed create permissions.</field>
+    <!-- Portal/Base Users Access Rules -->
+    <record id="portal_rule_file_computed_read" model="ir.rule">
+        <field name="name">Portal Personal Files Read</field>
         <field name="model_id" ref="model_dms_file" />
-        <field name="global" eval="True" />
-        <field name="perm_read" eval="0" />
-        <field name="perm_create" eval="1" />
-        <field name="perm_write" eval="0" />
-        <field name="perm_unlink" eval="0" />
-        <field name="domain_force">[('permission_create', '=', user.id)]</field>
-    </record>
-    <record id="rule_file_computed_read" model="ir.rule">
-        <field name="name">Apply computed read permissions.</field>
-        <field name="model_id" ref="model_dms_file" />
-        <field name="global" eval="True" />
-        <field name="perm_read" eval="1" />
-        <field name="perm_create" eval="0" />
-        <field name="perm_write" eval="0" />
-        <field name="perm_unlink" eval="0" />
-        <field name="domain_force">[('permission_read', '=', user.id)]</field>
-    </record>
-    <record id="rule_file_computed_unlink" model="ir.rule">
-        <field name="name">Apply computed unlink permissions.</field>
-        <field name="model_id" ref="model_dms_file" />
-        <field name="global" eval="True" />
-        <field name="perm_read" eval="0" />
-        <field name="perm_create" eval="0" />
-        <field name="perm_write" eval="0" />
-        <field name="perm_unlink" eval="1" />
-        <field name="domain_force">[('permission_unlink', '=', user.id)]</field>
-    </record>
-    <record id="rule_file_computed_write" model="ir.rule">
-        <field name="name">Apply computed write permissions.</field>
-        <field name="model_id" ref="model_dms_file" />
-        <field name="global" eval="True" />
-        <field name="perm_read" eval="0" />
-        <field name="perm_create" eval="0" />
-        <field name="perm_write" eval="1" />
-        <field name="perm_unlink" eval="0" />
-        <field name="domain_force">[('permission_write', '=', user.id)]</field>
+        <field name="global" eval="False" />
+        <field
+            name="domain_force"
+        >[('message_partner_ids','child_of',[user.commercial_partner_id.id])]</field>
+        <field
+            name="groups"
+            eval="[Command.link(ref('base.group_portal')), Command.link(ref('base.group_user'))]"
+        />
+        <field name="perm_unlink" eval="False" />
+        <field name="perm_write" eval="False" />
+        <field name="perm_read" eval="True" />
+        <field name="perm_create" eval="False" />
     </record>
 </odoo>

--- a/dms/static/description/index.html
+++ b/dms/static/description/index.html
@@ -510,6 +510,8 @@ group in directories, so they will see in the portal such directories
 and their files. Another possibility is to click on “Share” button
 inside a directory or a file for obtaining a tokenized link for single
 access to that resource, no matter if logged or not.</p>
+<p>For any file if you add the portal user or the internal user to
+followers mixin, they can read that file.</p>
 </div>
 </div>
 <div class="section" id="known-issues-roadmap">

--- a/dms/tests/test_portal.py
+++ b/dms/tests/test_portal.py
@@ -44,6 +44,17 @@ class TestDmsPortal(odoo.tests.HttpCase, StorageAttachmentBaseCase):
         )
 
     def test_tour(self):
+        file_id = self.env.ref("dms.file_11_demo")
+        follower = self.env["mail.followers"].create(
+            {
+                "res_model": "dms.file",
+                "res_id": file_id.id,
+                "partner_id": self.portal_user.partner_id.id,
+                "is_active": True,
+            }
+        )
+
+        file_id.message_follower_ids = follower
         for tour in ("dms_portal_mail_tour", "dms_portal_partners_tour"):
             with self.subTest(tour=tour):
                 self.start_tour("/my", tour, login="portal")

--- a/dms/views/dms_directory.xml
+++ b/dms/views/dms_directory.xml
@@ -386,7 +386,15 @@
         <field name="model">dms.directory</field>
         <field name="arch" type="xml">
             <form>
-                <header />
+                <header>
+                    <button
+                        class="oe_highlight"
+                        name="%(dms.wizard_dms_directory_share_action)d"
+                        type="action"
+                        string="Share"
+                        groups="dms.group_dms_manager"
+                    />
+                </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
                         <button

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -344,6 +344,7 @@
                         type="object"
                         string="Lock"
                         invisible="is_locked or not permission_write"
+                        groups="dms.group_dms_user"
                     />
                     <button
                         class="oe_highlight"
@@ -351,6 +352,14 @@
                         type="object"
                         string="Unlock"
                         invisible="not is_locked or not is_lock_editor"
+                        groups="dms.group_dms_user"
+                    />
+                    <button
+                        class="oe_highlight"
+                        name="%(dms.wizard_dms_file_share_action)d"
+                        type="action"
+                        string="Share"
+                        groups="dms.group_dms_user"
                     />
                 </header>
                 <sheet>

--- a/dms/views/menu.xml
+++ b/dms/views/menu.xml
@@ -11,7 +11,7 @@
         id="main_menu_dms"
         name="Documents"
         web_icon="dms,static/description/icon.png"
-        groups="group_dms_user"
+        groups="base.group_user"
     >
         <menuitem
             id="menu_dms_file"


### PR DESCRIPTION
based on migration to 18.0 PR #385 and focusing on updating security groups and rules for better functionality and privacy.

The value of this commit is to improve vunrable security layers of dms module for all groups:

- managers can access and edit files/dirs/groups even locked files they can edit and delete even hidden Storage they can access.
- dms users can access files/dirs NOT Storage, they can lock files on each other, only locker user can edit/delete except for managers.
- internal users are not dms users by default, but we can grant any internal user this group, they can not access any file/dir/storage, but only if we grant any user to be a follower of a specific file then granted user can access that file and its dir and still see ONLY the specific file within the dir.
- portal users are following a similar rule for base internal users, so our partners/customers can Only access files and dir that they are granted to follow and can never access any other files.
- public users are removed from all groups and rules for files/dirs/storage
- We returned the share button that allows anybody to access the files/dirs with a pass token, dms users and portal users are able to get and share that token. portal users can share their own granted files they access only.

There is now rules for tags/categories for internal users based on being followers to specific files, and also they can access files and their dirs via potal page.

We did not review the ability to upload a file in sale and delete it there whether it gets locked by some other user yet.
I hope to find people come here and cooperate for their sake and all community sake and for the public good.