### PR TITLE
[16.0][FIX] dms: Delete the file if the attachment is deleted

### DIFF
--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -202,6 +202,7 @@ class File(models.Model):
         prefetch=False,
         invisible=True,
         ondelete="cascade",
+        index=True,
     )
 
     def get_human_size(self):
@@ -618,6 +619,13 @@ class File(models.Model):
                 vals = self._create_model_attachment(vals)
             new_vals_list.append(vals)
         return super(File, self).create(new_vals_list)
+
+    def unlink(self):
+        attachments = self.mapped("attachment_id")
+        res = super().unlink()
+        if not self.env.context.get("dms_file"):
+            attachments.with_context(dms_file=True).unlink()
+        return res
 
     # ----------------------------------------------------------
     # Locking fields and functions

--- a/dms/models/ir_attachment.py
+++ b/dms/models/ir_attachment.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Tecnativa - Víctor Martínez
+# Copyright 2021-2025 Tecnativa - Víctor Martínez
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 from odoo import api, models
 from odoo.tools import ormcache
@@ -100,3 +100,10 @@ class IrAttachment(models.Model):
         ):
             self._dms_operations()
         return res
+
+    def unlink(self):
+        if not self.env.context.get("dms_file"):
+            self.env["dms.file"].search(
+                [("attachment_id", "in", self.ids)]
+            ).with_context(dms_file=True).unlink()
+        return super().unlink()

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -152,7 +152,7 @@
                                                 Unlock
                                             </a>
                                             <a
-                                                t-if="record.permission_write.raw_value and record.active.raw_value"
+                                                t-if="record.permission_write.raw_value and record.active.raw_value and (!record.is_locked.raw_value or (record.is_locked.raw_value and record.is_lock_editor.raw_value))"
                                                 role="menuitem"
                                                 name="toggle_active"
                                                 type="object"
@@ -162,7 +162,7 @@
                                                 Archive
                                             </a>
                                             <a
-                                                t-if="record.permission_write.raw_value and !record.active.raw_value"
+                                                t-if="record.permission_write.raw_value and !record.active.raw_value and (!record.is_locked.raw_value or (record.is_locked.raw_value and record.is_lock_editor.raw_value))"
                                                 role="menuitem"
                                                 name="toggle_active"
                                                 type="object"
@@ -204,7 +204,7 @@
                                                 Edit
                                             </a>
                                             <a
-                                                t-if="record.permission_unlink.raw_value"
+                                                t-if="record.permission_unlink.raw_value and (!record.is_locked.raw_value or (record.is_locked.raw_value and record.is_lock_editor.raw_value))"
                                                 role="menuitem"
                                                 type="delete"
                                                 class="dropdown-item"


### PR DESCRIPTION
Delete the file if the attachment is deleted

When deleting an attachment, an attempt should be made to delete the linked file, causing an error if it is locked. Do not show the Delete/Archive/Unarchive option on files if it is locked and you cannot unlock it.

Fixes https://github.com/OCA/dms/issues/381

@Tecnativa