### PR TITLE
[IMP] dms: Add functionality to assign linked attachments record ID its value

### DIFF
--- a/dms/__manifest__.py
+++ b/dms/__manifest__.py
@@ -40,6 +40,7 @@
         # Wizard
         "wizards/wizard_dms_file_move_views.xml",
         "wizards/wizard_dms_share_views.xml",
+        "wizards/wizard_dms_dir_record_view.xml",
     ],
     "assets": {
         "web.assets_backend": [

--- a/dms/models/directory.py
+++ b/dms/models/directory.py
@@ -540,10 +540,6 @@ class DmsDirectory(models.Model):
                 raise ValidationError(
                     _("A directory has to have model in attachment storage.")
                 )
-            if not record.is_root_directory and not record.res_id:
-                raise ValidationError(
-                    _("This directory needs to be associated to a record.")
-                )
 
     @api.constrains("is_root_directory", "storage_id")
     def _check_directory_storage(self):
@@ -767,3 +763,16 @@ class DmsDirectory(models.Model):
             searchpanel_default_directory_id=self.id,
         )
         return action
+
+    def button_add_res_id(self):
+        self.ensure_one()
+        return {
+            # context since 17.0 will be dropped in views
+            # unless we suffix it's key with _view_ref
+            "context": {"directory_id_view_ref": self.id},
+            "name": _("Linked attachments record ID Wizard"),
+            "view_mode": "form",
+            "res_model": "wizard.directory.record",
+            "type": "ir.actions.act_window",
+            "target": "new",
+        }

--- a/dms/security/ir.model.access.csv
+++ b/dms/security/ir.model.access.csv
@@ -25,3 +25,5 @@ access_security_access_groups_dms_user,access_security_access_groups_dms_user,mo
 
 access_wizard_dms_file_move,access_wizard_dms_file_move,model_wizard_dms_file_move,group_dms_user,1,1,1,1
 access_wizard_dms_share,access_wizard_dms_share,model_wizard_dms_share,group_dms_manager,1,1,1,0
+access_wizard_directory_record,access_wizard_directory_record,model_wizard_directory_record,group_dms_user,1,1,1,1
+access_record_placeholder,access_record_placeholder,model_record_placeholder,group_dms_user,1,1,1,1

--- a/dms/views/dms_directory.xml
+++ b/dms/views/dms_directory.xml
@@ -506,10 +506,20 @@
                             required="storage_id_save_type == 'attachment'"
                         />
                         <field name="res_model" invisible="1" force_save="1" />
+                        <button
+                            name="button_add_res_id"
+                            type="object"
+                            string="Load Linked attachments record ID"
+                            class="btn btn-link p-0"
+                            invisible="not model_id or
+                            storage_id_save_type != 'attachment' or
+                            (model_id and count_total_files > 0)"
+                        />
                         <field
                             name="res_id"
                             readonly="True"
                             invisible="storage_id_save_type != 'attachment'"
+                            required="model_id and not is_root_directory"
                         />
                         <field
                             name="record_ref"

--- a/dms/wizards/__init__.py
+++ b/dms/wizards/__init__.py
@@ -1,2 +1,3 @@
 from . import wizard_dms_file_move
 from . import wizard_dms_share
+from . import wizard_dms_dir_record

--- a/dms/wizards/wizard_dms_dir_record.py
+++ b/dms/wizards/wizard_dms_dir_record.py
@@ -1,0 +1,85 @@
+# Copyright 2025 Kencove - Mohamed Alkobrosli (https://kencove.com).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from lxml import etree
+
+from odoo import api, fields, models
+
+
+class RecordPlaceholder(models.TransientModel):
+    _name = "record.placeholder"
+    _description = "A placeholder model to enable virtual relational field res_id"
+
+
+class WizardDmsDirRecord(models.TransientModel):
+    _name = "wizard.directory.record"
+    _description = "Wizard Dms Directory Record ID"
+
+    directory_id = fields.Many2one(
+        comodel_name="dms.directory",
+        required=True,
+        string="Directory",
+        default=lambda self: self.env.context.get("directory_id_view_ref", False),
+    )
+    # Just a placeholder field
+    res_id = fields.Many2one(
+        "record.placeholder",
+        string="Linked attachments record ID",
+    )
+
+    def validate(self):
+        return True
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        dir_obj = self.env["dms.directory"]
+        for vals in vals_list:
+            res_id = vals.get("res_id")
+            dir_id = dir_obj.browse(vals["directory_id"])
+            # Todo as we can expand with more models for subscribtion like hr etc...
+            if dir_id.res_model in ["res.partner"]:
+                if dir_id.res_id and dir_id.res_id != res_id:
+                    dir_id.message_unsubscribe([dir_id.res_id])
+                subscribers = (
+                    [res_id]
+                    if res_id not in dir_id.sudo().message_partner_ids.ids
+                    else None
+                )
+                dir_id.message_subscribe(subscribers)
+            # Add the ID for the model
+            dir_id.write({"res_id": res_id})
+            # As the placeholder model is empty
+            # we should remove its relational virtual field from creation.
+            del vals["res_id"]
+        return super().create(vals_list)
+
+    @api.model
+    def get_views(self, views, options=None):
+        context = self.env.context
+        res = super().get_views(views, options=options)
+        if (
+            "views" in res
+            and "form" in res["views"]
+            and context
+            and context.get("directory_id_view_ref")
+        ):
+            dir_obj = self.env["dms.directory"]
+            dir_id = dir_obj.browse(context.get("directory_id_view_ref"))
+            model = dir_id.model_id
+            relation = model.model
+            res["models"][self._name]["fields"].update(
+                {
+                    "res_id": {
+                        "string": "Linked attachments record ID",
+                        "type": "many2one",
+                        "relation": relation,
+                        "required": True,
+                    }
+                }
+            )
+            eview = etree.fromstring(res["views"]["form"]["arch"])
+            options = etree.Element("field", name="res_id")
+            placeholder = eview.xpath("//separator[@string='options_placeholder']")[0]
+            placeholder.getparent().replace(placeholder, options)
+            res["views"]["form"]["arch"] = etree.tostring(eview, pretty_print=True)
+        return res

--- a/dms/wizards/wizard_dms_dir_record_view.xml
+++ b/dms/wizards/wizard_dms_dir_record_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="attribute_option_wizard_form_view" model="ir.ui.view">
+        <field name="name">wizard.directory.record</field>
+        <field name="model">wizard.directory.record</field>
+        <field name="arch" type="xml">
+            <form string="Options Wizard">
+                <field name="directory_id" invisible="1" />
+                <group>
+                    <separator string="options_placeholder" />
+                </group>
+                <footer>
+                    <button
+                        name="validate"
+                        string="Validate"
+                        type="object"
+                        class="oe_highlight"
+                    />
+                    <button string="Cancel" class="oe_link" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Similar to dms project we can select the model we want and then via a wizard,  we can select the record id/ids of the same kind of the chosen model.

In the followers section I add the record of selected id there `if the model is Partners`

Based on the issue I raised in #399 that the field is readonly and is required on the same time. This commit is solving the problem and making it no problem at all in the UI.