### PR TITLE
[17.0][FIX] dms: Delete the file if the attachment is deleted

### DIFF
--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -197,6 +197,7 @@ class DMSFile(models.Model):
         string="Attachment File",
         prefetch=False,
         ondelete="cascade",
+        index=True,
     )
 
     def get_human_size(self):
@@ -601,6 +602,13 @@ class DMSFile(models.Model):
                 vals = self._create_model_attachment(vals)
             new_vals_list.append(vals)
         return super().create(new_vals_list)
+
+    def unlink(self):
+        attachments = self.mapped("attachment_id")
+        res = super().unlink()
+        if not self.env.context.get("dms_file"):
+            attachments.with_context(dms_file=True).unlink()
+        return res
 
     # ----------------------------------------------------------
     # Locking fields and functions

--- a/dms/models/ir_attachment.py
+++ b/dms/models/ir_attachment.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Tecnativa - Víctor Martínez
+# Copyright 2021-2025 Tecnativa - Víctor Martínez
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 from odoo import api, models
 from odoo.tools import ormcache
@@ -99,3 +99,10 @@ class IrAttachment(models.Model):
         ):
             self._dms_operations()
         return res
+
+    def unlink(self):
+        if not self.env.context.get("dms_file"):
+            self.env["dms.file"].search(
+                [("attachment_id", "in", self.ids)]
+            ).with_context(dms_file=True).unlink()
+        return super().unlink()

--- a/dms/tests/test_storage_attachment.py
+++ b/dms/tests/test_storage_attachment.py
@@ -3,6 +3,7 @@
 # Copyright 2024 Subteno - Timothée Vannier (https://www.subteno.com).
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
+from odoo.exceptions import AccessError
 from odoo.tests.common import users
 from odoo.tools import mute_logger
 
@@ -47,6 +48,26 @@ class StorageAttachmentTestCase(StorageAttachmentBaseCase):
         directory.res_id = -1  # Trick to reference a non-existing record
         directories = self.env["dms.directory"].search([])
         self.assertNotIn(directory.id, directories.ids)
+
+    @mute_logger("odoo.models.unlink")
+    def test_storage_attachment_unlink_lock_file(self):
+        group_partner_manager = self.env.ref("base.group_partner_manager")
+        self.dms_manager_user.write({"groups_id": [(4, group_partner_manager.id)]})
+        self.dms_user.write({"groups_id": [(4, group_partner_manager.id)]})
+        attachment = self._create_attachment("demo.txt")
+        attachment = attachment.with_user(self.dms_manager_user)
+        file = self.storage.storage_file_ids.filtered(lambda x: x.name == "demo.txt")
+        file.with_user(self.dms_user).lock()
+        self.assertTrue(file.is_locked)
+        self.assertFalse(file.is_lock_editor)
+        with self.assertRaises(AccessError):
+            attachment.unlink()
+        self.assertTrue(file.exists())
+        file.with_user(self.dms_user).unlock()
+        self.assertFalse(file.is_locked)
+        file.invalidate_recordset()
+        attachment.unlink()
+        self.assertFalse(file.exists())
 
     @users("dms-manager")
     def test_storage_attachment_misc(self):
@@ -105,6 +126,8 @@ class StorageAttachmentTestCase(StorageAttachmentBaseCase):
         self.assertEqual(
             self.storage.count_storage_files, 2, "Storage should have 2 files"
         )
+        dms_file.unlink()
+        self.assertFalse(attachment.exists())
 
     @users("dms-manager")
     def test_storage_attachment_directory_record_ref_access_dms_manager(self):

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -142,7 +142,7 @@
                                     </div>
                                     <div
                                         role="menuitem"
-                                        t-if="record.permission_write.raw_value and record.active.raw_value"
+                                        t-if="record.permission_write.raw_value and record.active.raw_value and (!record.is_locked.raw_value or (record.is_locked.raw_value and record.is_lock_editor.raw_value))"
                                     >
                                         <a name="toggle_active" type="object">
                                             <i class="fa fa-archive" />
@@ -151,7 +151,7 @@
                                     </div>
                                     <div
                                         role="menuitem"
-                                        t-if="record.permission_write.raw_value and !record.active.raw_value"
+                                        t-if="record.permission_write.raw_value and !record.active.raw_value and (!record.is_locked.raw_value or (record.is_locked.raw_value and record.is_lock_editor.raw_value))"
                                     >
                                         <a name="toggle_active" type="object">
                                             <i class="fa fa-archive" />
@@ -191,7 +191,7 @@
                                     </div>
                                     <div
                                         role="menuitem"
-                                        t-if="record.permission_unlink.raw_value"
+                                        t-if="record.permission_unlink.raw_value and (!record.is_locked.raw_value or (record.is_locked.raw_value and record.is_lock_editor.raw_value))"
                                     >
                                         <a type="delete">
                                             <i class="fa fa-trash-o" />


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/dms/pull/397

Delete the file if the attachment is deleted

When deleting an attachment, an attempt should be made to delete the linked file, causing an error if it is locked. Do not show the Delete/Archive/Unarchive option on files if it is locked and you cannot unlock it.

Fixes https://github.com/OCA/dms/issues/381

@Tecnativa