### PR TITLE
[18.0][FIX] dms: Show full file name in kanban view

### DIFF
--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -231,7 +231,7 @@
                                     </a>
                                 </div>
                                 <div class="col-9">
-                                    <field name="name" class="text-truncate fw-bold" />
+                                    <field name="name" class="fw-bold" />
                                     <field
                                         name="tag_ids"
                                         widget="many2many_tags"


### PR DESCRIPTION
Show full file name in kanban view.

**Before**
![antes](https://github.com/user-attachments/assets/4072d851-ea47-4a0e-9596-37888b4a0bd0)

**After**
![despues](https://github.com/user-attachments/assets/3ec62034-aa79-4240-8f59-75a79cf95368)

Fixes #402 https://github.com/OCA/dms/issues/402

@Tecnativa