### PR TITLE
[17.0][FIX] dms: Show short name of directories in searchpanel

### DIFF
--- a/dms/models/directory.py
+++ b/dms/models/directory.py
@@ -698,6 +698,14 @@ class DmsDirectory(models.Model):
             res = super().write(vals)
         return res
 
+    @api.depends_context("directory_short_name")
+    def _compute_display_name(self):
+        if self.env.context.get("directory_short_name"):
+            for item in self:
+                item.display_name = item.name
+        else:
+            return super()._compute_display_name()
+
     def unlink(self):
         """Custom cascade unlink.
 


### PR DESCRIPTION
Show short name of directories in searchpanel

**Before**
![antes](https://github.com/user-attachments/assets/8f78c1ad-9638-436d-8edb-70020da1cea1)

**After**
![despues](https://github.com/user-attachments/assets/825ba335-c6c2-4ccd-a7fe-611720d1d896)

Fixes #408 

@Tecnativa