### PR TITLE
[16.0][FIX] dms: searchpanel changes apply only to dms

### DIFF
--- a/dms/static/src/js/views/search_panel.esm.js
+++ b/dms/static/src/js/views/search_panel.esm.js
@@ -17,7 +17,10 @@ patch(SearchModel.prototype, "dms.SearchPanel", {
                 continue;
             }
 
-            if (category.activeValueId) {
+            // Make sure to filter selected category only for DMS hierarchies,
+            // not other Odoo models such as product categories
+            // where child_of could be better than "=" operator
+            if (category.activeValueId && this.resModel.startsWith("dms")) {
                 domain.push([category.fieldName, "=", category.activeValueId]);
             }
             if (domain.length === 0 && this.resModel === "dms.directory") {


### PR DESCRIPTION
Original code in Odoo:

```
        /**
         * Computes and returns the domain based on the current active
         * categories. If "excludedCategoryId" is provided, the category with
         * that id is not taken into account in the domain computation.
         * @private
         * @param {string} [excludedCategoryId]
         * @returns {Array[]}
         */
        _getCategoryDomain(excludedCategoryId) {
            const domain = [];
            for (const category of this.categories) {
                if (
                    category.id === excludedCategoryId ||
                    !category.activeValueId
                ) {
                    continue;
                }
                const field = this.config.fields[category.fieldName];
                const operator =
                    field.type === "many2one" && category.parentField ? "child_of" : "=";
                domain.push([
                    category.fieldName,
                    operator,
                    category.activeValueId,
                ]);
            }
            return domain;
        }
```

Which means that if searchpanel is added anywhere else with parent relationship it will use operators different than "=".

i.e. in dialogs, product lists (replenishment tab) or custom views

This PR restricts filtering selected category to dms module, where it was tested and nobody complained, but does not modify the rest of Odoo. 

Whether it should be customisable or not in the searchpanel parameters in vanilla odoo, that is another topic :)