### PR TITLE
[18.0][FIX] dms_field: Use the appropriate model for the creation of the file/directory structure according to the template

### DIFF
--- a/dms_field/static/src/views/dms_list/dms_list_controller.esm.js
+++ b/dms_field/static/src/views/dms_list/dms_list_controller.esm.js
@@ -459,7 +459,7 @@ export function getDMSListControllerObject() {
         },
         onDMSCreateEmptyStorages() {
             var data = {
-                model: this.resModel,
+                model: this.sanitizeDMSModel(this.resModel),
                 empty_storages: this.empty_storages,
                 res_id: this.props.record.resId,
             };


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/dms/pull/425

Use the appropriate model for the creation of the file/directory structure according to the template

Use case example:
- Install module `hr_dms_field`
- Remove the Employees > Administrator permission for user Marc Demo
- Log in with the user Marc Demo
- Go to the Marc Demo employee
- Go to the Documents tab and click on the corresponding icon to create the structure.

Please @CarlosRoca13 can you review it?

@Tecnativa TT55524