### PR TITLE
[18.0][FIX] dms_field: Avoid error when accessing storage form view

### DIFF
--- a/dms_field/README.rst
+++ b/dms_field/README.rst
@@ -122,6 +122,14 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
+.. |maintainer-CarlosRoca13| image:: https://github.com/CarlosRoca13.png?size=40px
+    :target: https://github.com/CarlosRoca13
+    :alt: CarlosRoca13
+
+Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
+
+|maintainer-CarlosRoca13| 
+
 This module is part of the `OCA/dms <https://github.com/OCA/dms/tree/18.0/dms_field>`_ project on GitHub.
 
 You are welcome to contribute. To learn how please visit https://odoo-community.org/page/Contribute.

--- a/dms_field/__manifest__.py
+++ b/dms_field/__manifest__.py
@@ -30,4 +30,5 @@
         ],
     },
     "demo": ["demo/partner_dms.xml"],
+    "maintainers": ["CarlosRoca13"],
 }

--- a/dms_field/static/description/index.html
+++ b/dms_field/static/description/index.html
@@ -468,6 +468,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/CarlosRoca13"><img alt="CarlosRoca13" src="https://github.com/CarlosRoca13.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/dms/tree/18.0/dms_field">OCA/dms</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/dms_field/static/src/views/dms_list/dms_list_controller.esm.js
+++ b/dms_field/static/src/views/dms_list/dms_list_controller.esm.js
@@ -62,8 +62,8 @@ export function getDMSListControllerObject() {
             var autocompute_directory = false;
             var show_storage = true;
             if (model === "dms.storage") {
-                if (this.model.root.data && this.model.root.data.id) {
-                    storage_domain = [["id", "=", this.model.root.data.id]];
+                if (this.model.root.resId) {
+                    storage_domain = [["id", "=", this.model.root.resId]];
                 } else {
                     storage_domain = [
                         [


### PR DESCRIPTION
Related to https://github.com/OCA/dms/pull/416

Avoid error when accessing storage form view

**Before**
![antes](https://github.com/user-attachments/assets/514a5c20-e6cf-4f4c-9f49-b60397728def)

**After**
![despues](https://github.com/user-attachments/assets/fadcb618-2607-4562-93b3-acc8a6b74088)

Please @CarlosRoca13 can you review it?

@Tecnativa