### PR TITLE
[16.0][FIX] using content_binary in database when using dms_storage, file stored twice

### DIFF
--- a/dms_storage/models/dms_file.py
+++ b/dms_storage/models/dms_file.py
@@ -24,6 +24,8 @@ class DmsFile(models.Model):
             self.storage_id.storage_backend_id.add(storage_path, binary)
             result["storage_path"] = storage_path
             result["storage_backend_id"] = self.storage_id.storage_backend_id.id
+            result["content_binary"] = self.storage_id.storage_backend_id.id
+            result["content_file"] = self.storage_id.storage_backend_id.id
         return result
 
     @api.depends("storage_path")

--- a/dms_storage/models/dms_file.py
+++ b/dms_storage/models/dms_file.py
@@ -24,8 +24,8 @@ class DmsFile(models.Model):
             self.storage_id.storage_backend_id.add(storage_path, binary)
             result["storage_path"] = storage_path
             result["storage_backend_id"] = self.storage_id.storage_backend_id.id
-            result["content_binary"] = self.storage_id.storage_backend_id.id
-            result["content_file"] = self.storage_id.storage_backend_id.id
+            result["content_binary"] = False
+            result["content_file"] = False
         return result
 
     @api.depends("storage_path")


### PR DESCRIPTION
When using dms_storage the content_file and content_binary can be set because the file save_type stay unchange and set those fields in _update_content_vals