### PR TITLE
[18.0][FIX] dms: Check that the create/write/unlink methods can be executed

### DIFF
--- a/dms/models/dms_security_mixin.py
+++ b/dms/models/dms_security_mixin.py
@@ -275,6 +275,17 @@ class DmsSecurityMixin(models.AbstractModel):
         result |= self._filtered_access_no_recursion(operation)
         return result
 
+    def _check_access_dms_record(self, operation: str) -> tuple | None:
+        """Specific method "similar" to _check_access() but with a different
+        behavior: check if you do not really have access to any of the records
+        in to avoid performing the corresponding create/write/unlink action."""
+        if any(self._ids) and not self.env.su:
+            Rule = self.env["ir.rule"]
+            domain = Rule._compute_domain(self._name, operation)
+            items = self.search(domain)
+            if any(x_id not in items.ids for x_id in self.ids):
+                raise Rule._make_access_error(operation, (self - items))
+
     @api.model_create_multi
     def create(self, vals_list):
         # Create as sudo to avoid testing creation permissions before DMS security
@@ -285,5 +296,13 @@ class DmsSecurityMixin(models.AbstractModel):
         res.flush_recordset()
         # Go back to the original sudo state and check we really had creation permission
         res = res.sudo(self.env.su)
-        res.check_access("create")
+        res._check_access_dms_record("create")
         return res
+
+    def write(self, vals):
+        self._check_access_dms_record("write")
+        return super().write(vals)
+
+    def unlink(self):
+        self._check_access_dms_record("unlink")
+        return super().unlink()

--- a/dms/tests/test_directory.py
+++ b/dms/tests/test_directory.py
@@ -6,7 +6,9 @@
 
 import os
 
-from odoo.exceptions import UserError
+from odoo import Command
+from odoo.exceptions import AccessError, UserError
+from odoo.tests import new_test_user
 from odoo.tests.common import users
 from odoo.tools import mute_logger
 
@@ -265,6 +267,18 @@ class DirectoryTestCaseBase(StorageDatabaseBaseCase):
             self.directory_model.search_panel_select_multi_range("tag_ids"),
             msg="The tag_ids field should be a multi range field",
         )
+
+    def test_directory_unlink_custom(self):
+        user = new_test_user(
+            self.env, login="test-dms-customer-user", groups="dms.group_dms_user"
+        )
+        group = self.access_group_model.create(
+            {"name": "Test read group", "explicit_user_ids": [Command.set(user.ids)]}
+        )
+        root_directory = self.create_directory(storage=self.storage)
+        root_directory.group_ids = [Command.link(group.id)]
+        with self.assertRaises(AccessError):
+            root_directory.with_user(user).unlink()
 
 
 class DirectoryMailTestCase(StorageDatabaseBaseCase):


### PR DESCRIPTION
Check that the create/write/unlink methods can be executed

Related to https://github.com/OCA/dms/pull/435

Fixes https://github.com/OCA/dms/pull/435

@Tecnativa