### PR TITLE
[16.0][FIX]dms: Error with o-text-overflow on the o_kanban_details_wrapper div.

### DIFF
--- a/dms/static/src/scss/directory_kanban.scss
+++ b/dms/static/src/scss/directory_kanban.scss
@@ -54,6 +54,7 @@
             .o_kanban_record_title {
                 font-weight: bold;
                 padding-right: 16px;
+                @include o-text-overflow(block);
             }
             .o_kanban_record_body {
                 max-height: 12px;

--- a/dms/static/src/scss/file_kanban.scss
+++ b/dms/static/src/scss/file_kanban.scss
@@ -23,6 +23,7 @@
             .o_kanban_record_title {
                 font-weight: bold;
                 padding-right: 16px;
+                @include o-text-overflow(block);
             }
             .o_kanban_record_body {
                 max-height: 12px;

--- a/dms/views/directory.xml
+++ b/dms/views/directory.xml
@@ -338,9 +338,7 @@
                                 </div>
                                 <div class="o_kanban_details">
                                     <div class="o_kanban_details_wrapper">
-                                        <div
-                                            class="o_kanban_record_title o_text_overflow"
-                                        >
+                                        <div class="o_kanban_record_title">
                                             <field name="name" />
                                         </div>
                                         <div class="o_kanban_record_body">
@@ -550,7 +548,7 @@
                                 <tree limit="10">
                                     <field name="name" />
                                     <field name="mimetype" />
-                                     <field name="human_size" string="Size" />
+                                    <field name="human_size" string="Size" />
                                     <field name="write_date" readonly="1" />
                                 </tree>
                             </field>

--- a/dms/views/dms_file.xml
+++ b/dms/views/dms_file.xml
@@ -245,9 +245,7 @@
                                 </div>
                                 <div class="o_kanban_details">
                                     <div class="o_kanban_details_wrapper">
-                                        <div
-                                            class="o_kanban_record_title o_text_overflow"
-                                        >
+                                        <div class="o_kanban_record_title">
                                             <field name="name" />
                                         </div>
                                         <div class="o_kanban_record_body">
@@ -673,5 +671,4 @@
             action = model.action_wizard_dms_file_move()
         </field>
     </record>
-
 </odoo>


### PR DESCRIPTION
Good morning, it seems that sometimes the directory or file name causes a line break and pushes the text outside of the template. I haven't been able to reproduce the issue in other environments, not even in the same one, where there are folders with longer names that work fine. I’ve tested it on different screens, and the result varies. Forcing display: block; seems to fix the issue.



![Captura desde 2025-06-16 15-39-12](https://github.com/user-attachments/assets/58766fa6-5fd0-44d3-bb74-82395d42c3d7)

