### PR TITLE
[18.0][FIX]dms: Added a check that prevents DB curruption

### DIFF
--- a/dms/models/access_groups.py
+++ b/dms/models/access_groups.py
@@ -175,3 +175,16 @@ class DmsAccessGroups(models.Model):
                         "current": one.display_name,
                     }
                 )
+
+    # Prevent deletion of groups that are assigned to directories
+    def unlink(self):
+        for record in self:
+            if record.complete_directory_ids and record.complete_directory_ids.ids:
+                raise ValidationError(
+                    _(
+                        "You cannot delete the group '%(name)s' because it is assigned "
+                        + "to directories."
+                    )
+                    % {"name": record.name}
+                )
+        return super().unlink()


### PR DESCRIPTION
When an access group is deleted without removing the related directories, the user will be stucked with errors when trying to create new directories. It happens when you have only one Access Group in the dms module