### PR TITLE
[18.0] [FIX] Aligns `_find_record_check_access` with core

### DIFF
--- a/web_editor_media_dialog_dms/models/ir_binary.py
+++ b/web_editor_media_dialog_dms/models/ir_binary.py
@@ -7,9 +7,9 @@ from odoo import models
 class IrBinary(models.AbstractModel):
     _inherit = "ir.binary"
 
-    def _find_record_check_access(self, record, access_token):
+    def _find_record_check_access(self, record, access_token, field=None):
         # The method is overridden to allow access to the media attached to the
         # dms.file records using an access_token.
         if record._name == "dms.file":
             return record.validate_access(access_token)
-        return super()._find_record_check_access(record, access_token)
+        return super()._find_record_check_access(record, access_token, field=field)


### PR DESCRIPTION
Updates the signature of the `_find_record_check_access` method to match recent changes in Odoo core. This ensures compatibility and prevents potential issues by correctly handling the new `field` parameter.