### PR TITLE
[18.0][FIX] dms: Fix the inheritance of the search_panel so that the domain is applied correctly.

### DIFF
--- a/dms/static/src/js/views/search_panel.esm.js
+++ b/dms/static/src/js/views/search_panel.esm.js
@@ -3,12 +3,13 @@
  * License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). */
 
 import {SearchModel} from "@web/search/search_model";
+import {patch} from "@web/core/utils/patch";
 
-export class DMSSearchPanel extends SearchModel {
+patch(SearchModel.prototype, {
     _getCategoryDomain(excludedCategoryId) {
         const domain = super._getCategoryDomain(...arguments);
         for (const category of this.categories) {
-            if (category.id === Number(excludedCategoryId)) {
+            if (category.id === excludedCategoryId) {
                 continue;
             }
 
@@ -23,5 +24,5 @@ export class DMSSearchPanel extends SearchModel {
             }
         }
         return domain;
-    }
-}
+    },
+});


### PR DESCRIPTION
Before these changes, the domain was never applied to search by the parent, so all subfolders were being displayed instead of only the direct children of the selected one.

After making the changes, only a single level of folders is shown, without displaying all descendant folders.

cc @Tecnativa TT59933

ping @victoralmau @pedrobaeza 