### PR TITLE
[17.0][FIX] dms: Change save_type when migrate to another storage

### DIFF
--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -117,6 +117,8 @@ class DMSFile(models.Model):
         compute="_compute_save_type",
         string="Current Save Type",
         prefetch=False,
+        readonly=False,
+        store=True,
     )
 
     migration = fields.Char(
@@ -263,6 +265,7 @@ class DMSFile(models.Model):
                 {
                     "content": dms_file.with_context(**{}).content,
                     "storage_id": dms_file.directory_id.storage_id.id,
+                    "save_type": dms_file.directory_id.storage_id.save_type,
                 }
             )
 


### PR DESCRIPTION
When migrating files from one storage to another, their save type needs to change to match the storage's **save_type**. After that, these files will no longer require migration.

cc https://github.com/APSL 38655
@miquelalzanillas @lbarry-apsl @javierobcn @mpascuall @BernatObrador @ppyczko please review