### PR TITLE
[18.0][FIX] dms: allow unarchiving DMS files for non-superusers

### DIFF
--- a/dms/models/dms_security_mixin.py
+++ b/dms/models/dms_security_mixin.py
@@ -282,7 +282,7 @@ class DmsSecurityMixin(models.AbstractModel):
         if any(self._ids) and not self.env.su:
             Rule = self.env["ir.rule"]
             domain = Rule._compute_domain(self._name, operation)
-            items = self.search(domain)
+            items = self.with_context(active_test=False).search(domain)
             if any(x_id not in items.ids for x_id in self.ids):
                 raise Rule._make_access_error(operation, (self - items))
 


### PR DESCRIPTION
## Summary

Fixed a bug where non-superuser users cannot unarchive DMS files even when they have full write permissions through DMS access groups.

## Root Cause

`_check_access_dms_record()` in `dms_security_mixin.py` uses `self.search(domain)` to verify write permissions. By default, `search()` applies `active_test=True`, which excludes archived records (`active=False`).

When a user tries to unarchive a file via `toggle_active()`:
1. The write triggers `_check_access_dms_record()`
2. The method searches for the file with the computed ir.rule domain
3. But `search()` filters out archived records → file not found
4. AccessError raised even though user has write permission

## Fix

Add `active_test=False` context to the search in `_check_access_dms_record()` so archived records are included in the permission check.

## Steps to reproduce

1. Create a DMS file with proper access group permissions (write=True)
2. Archive the file
3. Try to unarchive (toggle_active) as a non-superuser
4. AccessError: "Apply computed write permissions"

## Testing

- Unarchive works for users with write permission via DMS access groups
- No impact on other permission checks (create, read, unlink)
- Superuser behavior unchanged (already bypassed via `self.env.su`)