### PR TITLE
[18.0][FIX] dms_field: Remove warning

### DIFF
--- a/dms_field/models/ir_ui_view.py
+++ b/dms_field/models/ir_ui_view.py
@@ -18,7 +18,7 @@ class IrUiView(models.Model):
 
     def _postprocess_tag_dms_list(self, node, name_manager, node_info):
         parent = node.getparent()
-        if parent_name := parent and parent.get("name"):
+        if parent is not None and (parent_name := parent.get("name")):
             field = name_manager.model._fields.get(parent_name)
             if field:
                 group_definitions = self.env["res.groups"]._get_group_definitions()


### PR DESCRIPTION
Remove warning

If, for example, `l10n_es_aeat_mod190` is installed and the tests are run, the following log is generated:

```
WARNING devel py.warnings: /opt/odoo/auto/addons/dms_field/models/ir_ui_view.py:21:
FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead

File "/opt/odoo/auto/addons/dms_field/models/ir_ui_view.py", line 21, in _postprocess_tag_dms_list
    if parent_name := parent and parent.get("name"):
```

Please @CarlosRoca13 and @pedrobaeza can you review it?

@Tecnativa