### PR TITLE
[18.0][FIX] dms_field: scope autocomputed directories by model

### DIFF
--- a/dms_field/__manifest__.py
+++ b/dms_field/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "DMS Field",
     "summary": """
         Create DMS View and allow to use them inside a record""",
-    "version": "18.0.1.2.0",
+    "version": "18.0.1.2.1",
     "license": "LGPL-3",
     "author": "Creu Blanca,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/dms",

--- a/dms_field/static/src/views/dms_list/dms_list_controller.esm.js
+++ b/dms_field/static/src/views/dms_list/dms_list_controller.esm.js
@@ -440,7 +440,10 @@ export function getDMSListControllerObject() {
             if (autocompute_directory) {
                 result = Domain.and([
                     result,
-                    new Domain([["res_id", "=", this.model.root.resId]]),
+                    new Domain([
+                        ["res_id", "=", this.model.root.resId],
+                        ["res_model", "=", this.sanitizeDMSModel(this.resModel)],
+                    ]),
                 ]);
             } else {
                 result = Domain.and([result, new Domain(domain || [])]);


### PR DESCRIPTION
Autocomputed DMS directories for embedded record views were filtered only by `res_id`.

Because record IDs are not globally unique across Odoo models, this could make a record such as `hr.employee,1` show directories belonging to another model with the same ID, for example `dms.field.template,1`.

This change scopes the autocomputed directory domain by both `res_id` and `res_model`.

Tested:
- `node --check dms_field/static/src/views/dms_list/dms_list_controller.esm.js`
- `git diff --check`