### PR TITLE
[18.0][ADD] dms_file_description: add descriptions to DMS files

### DIFF
--- a/dms_field_file_description_preview/README.md
+++ b/dms_field_file_description_preview/README.md
@@ -1,0 +1,12 @@
+# DMS Field File Description Preview
+
+Shows DMS file descriptions in the embedded DMS preview pane provided by `dms_field`.
+
+## Usage
+
+Install this module together with `dms_field` and `dms_file_description`. When a file is
+selected in an embedded DMS tree, its description is shown in the preview pane.
+
+## Contributors
+
+- Keith Brandenburg

--- a/dms_field_file_description_preview/__manifest__.py
+++ b/dms_field_file_description_preview/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    "name": "DMS Field File Description Preview",
+    "summary": "Shows DMS file descriptions in embedded DMS preview panes",
+    "version": "18.0.1.0.0",
+    "license": "AGPL-3",
+    "category": "Document Management",
+    "author": "Keith Brandenburg, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/dms",
+    "depends": ["dms_field", "dms_file_description"],
+    "assets": {
+        "web.assets_backend": [
+            "dms_field_file_description_preview/static/src/js/"
+            "dms_document_preview_description.esm.js",
+            "dms_field_file_description_preview/static/src/scss/"
+            "dms_field_file_description_preview.scss",
+        ],
+    },
+    "auto_install": True,
+    "installable": True,
+    "application": False,
+}

--- a/dms_field_file_description_preview/pyproject.toml
+++ b/dms_field_file_description_preview/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "odoo-addon-dms-field-file-description-preview"
+
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/dms_field_file_description_preview/readme/CONTRIBUTORS.md
+++ b/dms_field_file_description_preview/readme/CONTRIBUTORS.md
@@ -1,0 +1,1 @@
+- Keith Brandenburg

--- a/dms_field_file_description_preview/readme/DESCRIPTION.md
+++ b/dms_field_file_description_preview/readme/DESCRIPTION.md
@@ -1,0 +1,2 @@
+Shows DMS file descriptions in the embedded DMS preview pane provided by
+`dms_field`.

--- a/dms_field_file_description_preview/readme/USAGE.md
+++ b/dms_field_file_description_preview/readme/USAGE.md
@@ -1,0 +1,3 @@
+Install this module together with `dms_field` and `dms_file_description`.
+When a file is selected in an embedded DMS tree, its description is shown in
+the preview pane.

--- a/dms_field_file_description_preview/static/src/js/dms_document_preview_description.esm.js
+++ b/dms_field_file_description_preview/static/src/js/dms_document_preview_description.esm.js
@@ -1,0 +1,228 @@
+/** @odoo-module **/
+
+import {registry} from "@web/core/registry";
+
+const DESCRIPTION_BLOCK_CLASS = "o_dms_document_preview_description";
+const DESCRIPTION_TEXT_CLASS = "o_dms_document_preview_description_text";
+
+function parseFileIdFromPreview(previewEl) {
+    const contentLink = previewEl.querySelector(
+        'a[href*="/web/content"][href*="model=dms.file"], a[href*="/web/content?id="]'
+    );
+    const href = contentLink?.getAttribute("href") || "";
+    if (href) {
+        try {
+            const url = new URL(href, window.location.origin);
+            const id = url.searchParams.get("id");
+            if (id && /^\d+$/.test(id)) {
+                return Number.parseInt(id, 10);
+            }
+        } catch {
+            const match = href.match(/[?&]id=(\d+)/);
+            if (match) {
+                return Number.parseInt(match[1], 10);
+            }
+        }
+    }
+
+    const image = previewEl.querySelector('img[src*="/web/image/dms.file/"]');
+    const src = image?.getAttribute("src") || "";
+    const imageMatch = src.match(/\/web\/image\/dms\.file\/(\d+)\//);
+    if (imageMatch) {
+        return Number.parseInt(imageMatch[1], 10);
+    }
+
+    return null;
+}
+
+function descriptionBlock(previewEl) {
+    return previewEl.querySelector(`:scope > .${DESCRIPTION_BLOCK_CLASS}`);
+}
+
+function removeDescription(previewEl) {
+    const existing = descriptionBlock(previewEl);
+    if (existing) {
+        existing.remove();
+    }
+}
+
+function renderDescription(previewEl, description) {
+    const normalized = (description || "").trim();
+    if (!normalized) {
+        removeDescription(previewEl);
+        return;
+    }
+
+    let block = descriptionBlock(previewEl);
+    if (!block) {
+        block = document.createElement("div");
+        block.className = DESCRIPTION_BLOCK_CLASS;
+
+        const title = document.createElement("div");
+        title.className = "o_dms_document_preview_description_title";
+        title.textContent = "Description";
+
+        const text = document.createElement("div");
+        text.className = DESCRIPTION_TEXT_CLASS;
+
+        block.append(title, text);
+
+        const previewDirectory = previewEl.querySelector(
+            ":scope > .o_preview_directory"
+        );
+        if (previewDirectory) {
+            previewDirectory.insertAdjacentElement("afterend", block);
+        } else {
+            previewEl.append(block);
+        }
+    }
+
+    const textEl = block.querySelector(`.${DESCRIPTION_TEXT_CLASS}`);
+    if (textEl) {
+        textEl.textContent = normalized;
+    }
+}
+
+const dmsFileDescriptionPreviewService = {
+    dependencies: ["orm"],
+    start(env, {orm}) {
+        const pending = new Map();
+        const minPassiveRefreshMs = 10000;
+        let scheduled = null;
+
+        async function readDescription(fileId) {
+            // Do not cache completed descriptions here. DMS preview panes can be reused
+            // after editing a file in a dialog, and stale cached descriptions are very
+            // confusing. We only deduplicate concurrent reads for the same file.
+            if (pending.has(fileId)) {
+                return pending.get(fileId);
+            }
+
+            const promise = orm
+                .read("dms.file", [fileId], ["description"])
+                .then((records) => {
+                    pending.delete(fileId);
+                    return records?.[0]?.description || "";
+                })
+                .catch((error) => {
+                    pending.delete(fileId);
+                    // Keep this non-fatal. The preview pane should still work even if
+                    // permissions or transient DMS state prevent reading the description.
+                    console.warn(
+                        "Unable to load DMS file description for preview panel",
+                        fileId,
+                        error
+                    );
+                    return "";
+                });
+
+            pending.set(fileId, promise);
+            return promise;
+        }
+
+        async function updatePreview(previewEl, {force = false} = {}) {
+            const fileId = parseFileIdFromPreview(previewEl);
+            if (!fileId) {
+                removeDescription(previewEl);
+                delete previewEl.dataset.dmsFileDescriptionId;
+                delete previewEl.dataset.dmsFileDescriptionCheckedAt;
+                return;
+            }
+
+            const now = Date.now();
+            const idKey = String(fileId);
+            const previousId = previewEl.dataset.dmsFileDescriptionId;
+            const lastChecked = Number.parseInt(
+                previewEl.dataset.dmsFileDescriptionCheckedAt || "0",
+                10
+            );
+
+            // MutationObserver fires again when this service inserts/updates the block.
+            // Avoid repeatedly reading the same preview just because our own DOM changed.
+            if (
+                !force &&
+                previousId === idKey &&
+                descriptionBlock(previewEl) &&
+                now - lastChecked < minPassiveRefreshMs
+            ) {
+                return;
+            }
+
+            previewEl.dataset.dmsFileDescriptionId = idKey;
+            previewEl.dataset.dmsFileDescriptionCheckedAt = String(now);
+
+            const description = await readDescription(fileId);
+            // The preview may have changed while the RPC was pending.
+            if (parseFileIdFromPreview(previewEl) === fileId) {
+                renderDescription(previewEl, description);
+            }
+        }
+
+        function updateAllPreviews(options = {}) {
+            for (const previewEl of document.querySelectorAll(
+                ".dms_document_preview"
+            )) {
+                updatePreview(previewEl, options);
+            }
+        }
+
+        function schedulePassiveUpdate() {
+            if (scheduled) {
+                window.clearTimeout(scheduled);
+            }
+            scheduled = window.setTimeout(() => {
+                scheduled = null;
+                updateAllPreviews({force: false});
+            }, 80);
+        }
+
+        function scheduleForcedRefreshes() {
+            // A form save may still be in-flight when the click happens. Refresh a few
+            // times after likely save/close events so the preview catches the new
+            // description without requiring a full browser refresh.
+            for (const delay of [250, 900, 1800]) {
+                window.setTimeout(() => updateAllPreviews({force: true}), delay);
+            }
+        }
+
+        const observer = new MutationObserver(schedulePassiveUpdate);
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeFilter: ["src", "href", "class"],
+        });
+
+        document.body.addEventListener(
+            "click",
+            (event) => {
+                schedulePassiveUpdate();
+                // Refresh after likely file-detail saves or dialog confirm actions.
+                if (
+                    event.target.closest(
+                        ".o_form_button_save, .modal-footer .btn-primary, .o_dialog .btn-primary"
+                    )
+                ) {
+                    scheduleForcedRefreshes();
+                }
+            },
+            true
+        );
+        window.addEventListener("focus", scheduleForcedRefreshes);
+
+        schedulePassiveUpdate();
+
+        return {
+            update() {
+                updateAllPreviews({force: true});
+            },
+        };
+    },
+};
+
+registry
+    .category("services")
+    .add(
+        "dms_field_file_description_preview.preview_panel",
+        dmsFileDescriptionPreviewService
+    );

--- a/dms_field_file_description_preview/static/src/scss/dms_field_file_description_preview.scss
+++ b/dms_field_file_description_preview/static/src/scss/dms_field_file_description_preview.scss
@@ -1,0 +1,19 @@
+.dms_document_preview > .o_dms_document_preview_description {
+    margin-top: 0.75rem;
+    padding: 0.75rem;
+    border-top: 1px solid var(--border-color, #dee2e6);
+    white-space: normal;
+    overflow-wrap: anywhere;
+}
+
+.o_dms_document_preview_description_title {
+    font-weight: 600;
+    font-size: 0.875rem;
+    color: var(--text-muted, #6c757d);
+    margin-bottom: 0.25rem;
+}
+
+.o_dms_document_preview_description_text {
+    white-space: pre-wrap;
+    line-height: 1.35;
+}

--- a/dms_file_description/README.md
+++ b/dms_file_description/README.md
@@ -1,0 +1,20 @@
+# DMS File Description
+
+Adds an editable description field to DMS files.
+
+The description is shown in the standard DMS file form, list, search, and kanban views.
+
+## Usage
+
+To use this module:
+
+1. Go to **Documents**.
+2. Open or create a DMS file.
+3. Fill in the **Description** field.
+
+The description can be searched from the DMS file search view and is displayed as a
+short preview on DMS kanban cards.
+
+## Contributors
+
+- Keith Brandenburg

--- a/dms_file_description/__init__.py
+++ b/dms_file_description/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/dms_file_description/__manifest__.py
+++ b/dms_file_description/__manifest__.py
@@ -1,0 +1,20 @@
+{
+    "name": "DMS File Description",
+    "summary": "Adds editable descriptions to DMS files and displays them in DMS views",
+    "version": "18.0.1.0.0",
+    "license": "AGPL-3",
+    "category": "Document Management",
+    "author": "Keith Brandenburg, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/dms",
+    "depends": ["dms"],
+    "data": [
+        "views/dms_file_views.xml",
+    ],
+    "assets": {
+        "web.assets_backend": [
+            "dms_file_description/static/src/scss/dms_file_description.scss",
+        ],
+    },
+    "installable": True,
+    "application": False,
+}

--- a/dms_file_description/models/__init__.py
+++ b/dms_file_description/models/__init__.py
@@ -1,0 +1,1 @@
+from . import dms_file

--- a/dms_file_description/models/dms_file.py
+++ b/dms_file_description/models/dms_file.py
@@ -1,0 +1,28 @@
+from odoo import api, fields, models
+
+
+class DmsFile(models.Model):
+    _inherit = "dms.file"
+
+    description = fields.Text(
+        help="Notes about the file, purpose, status, or review context.",
+        tracking=True,
+    )
+    description_short = fields.Char(
+        string="Short Description",
+        compute="_compute_description_short",
+        help="Short version of the description used on DMS kanban cards.",
+    )
+
+    @api.depends("description")
+    def _compute_description_short(self):
+        limit = 35
+        for record in self:
+            text = (
+                (record.description or "").strip().replace("\r", " ").replace("\n", " ")
+            )
+            text = " ".join(text.split())
+            if len(text) > limit:
+                record.description_short = text[:limit].rstrip() + "..."
+            else:
+                record.description_short = text

--- a/dms_file_description/pyproject.toml
+++ b/dms_file_description/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/dms_file_description/readme/CONTRIBUTORS.md
+++ b/dms_file_description/readme/CONTRIBUTORS.md
@@ -1,0 +1,1 @@
+- Keith Brandenburg

--- a/dms_file_description/readme/DESCRIPTION.md
+++ b/dms_file_description/readme/DESCRIPTION.md
@@ -1,0 +1,4 @@
+Adds an editable description field to DMS files.
+
+The description is shown in the standard DMS file form, list, search, and kanban
+views.

--- a/dms_file_description/readme/USAGE.md
+++ b/dms_file_description/readme/USAGE.md
@@ -1,0 +1,8 @@
+To use this module:
+
+1. Go to **Documents**.
+2. Open or create a DMS file.
+3. Fill in the **Description** field.
+
+The description can be searched from the DMS file search view and is displayed
+as a short preview on DMS kanban cards.

--- a/dms_file_description/static/src/scss/dms_file_description.scss
+++ b/dms_file_description/static/src/scss/dms_file_description.scss
@@ -1,0 +1,6 @@
+.o_dms_file_description_kanban {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/dms_file_description/tests/__init__.py
+++ b/dms_file_description/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_dms_file_description

--- a/dms_file_description/tests/test_dms_file_description.py
+++ b/dms_file_description/tests/test_dms_file_description.py
@@ -1,0 +1,34 @@
+# Copyright 2026 Keith Brandenburg
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.addons.dms.tests.common import StorageDatabaseBaseCase
+
+
+class TestDmsFileDescription(StorageDatabaseBaseCase):
+    def test_description_short(self):
+        self.file.description = (
+            "  This is a long\nfile description that should be normalized "
+            "and shortened.  "
+        )
+
+        self.assertEqual(
+            self.file.description_short,
+            "This is a long file description tha...",
+        )
+
+    def test_description_short_empty(self):
+        self.file.description = False
+
+        self.assertFalse(self.file.description_short)
+
+    def test_description_search_filters(self):
+        arch, _view = self.file_model._get_view(view_type="search")
+
+        self.assertTrue(arch.xpath(".//filter[@name='has_description']"))
+        self.assertTrue(arch.xpath(".//filter[@name='missing_description']"))
+
+    def test_description_form_placeholder(self):
+        arch, _view = self.file_model._get_view(view_type="form")
+
+        description = arch.xpath(".//field[@name='description']")[0]
+        self.assertEqual(description.get("placeholder"), "Description")

--- a/dms_file_description/views/dms_file_views.xml
+++ b/dms_file_description/views/dms_file_views.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="search_dms_file_description" model="ir.ui.view">
+        <field name="name">dms.file.search.description</field>
+        <field name="model">dms.file</field>
+        <field name="inherit_id" ref="dms.search_dms_file" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='name']" position="after">
+                <field name="description" string="Description" />
+            </xpath>
+            <xpath expr="//filter[@name='filter_active']" position="after">
+                <separator />
+                <filter
+                    name="has_description"
+                    string="Has Description"
+                    domain="[('description', '!=', False)]"
+                />
+                <filter
+                    name="missing_description"
+                    string="Missing Description"
+                    domain="[('description', '=', False)]"
+                />
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_dms_file_kanban_description" model="ir.ui.view">
+        <field name="name">dms.file.kanban.description</field>
+        <field name="model">dms.file</field>
+        <field name="inherit_id" ref="dms.view_dms_file_kanban" />
+        <field name="arch" type="xml">
+            <xpath expr="//kanban/templates" position="before">
+                <field name="description" />
+                <field name="description_short" />
+            </xpath>
+            <xpath expr="//templates//field[@name='name']" position="after">
+                <div
+                    t-if="record.description_short.raw_value"
+                    class="o_dms_file_description_kanban text-muted mt-1 small"
+                    t-att-title="record.description.raw_value"
+                >
+                    <i class="fa fa-align-left me-1" role="img" title="Description" />
+                    <span t-esc="record.description_short.raw_value" />
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_dms_file_tree_description" model="ir.ui.view">
+        <field name="name">dms.file.list.description</field>
+        <field name="model">dms.file</field>
+        <field name="inherit_id" ref="dms.view_dms_file_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='name']" position="after">
+                <field name="description" optional="show" />
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_dms_file_form_description" model="ir.ui.view">
+        <field name="name">dms.file.form.description</field>
+        <field name="model">dms.file</field>
+        <field name="inherit_id" ref="dms.view_dms_file_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[hasclass('oe_title')]/h1" position="after">
+                <div class="o_dms_file_description_title mt-2">
+                    <field name="description" nolabel="1" placeholder="Description" />
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Adds two DMS modules:

- `dms_file_description`: adds editable descriptions to `dms.file` and displays them in DMS form, list, kanban, and search views.
- `dms_field_file_description_preview`: auto-install bridge that shows file descriptions in the embedded DMS preview pane from `dms_field`.

The preview integration is split from the base module so `dms_file_description` only depends on `dms`.

Tested on odoo-demo with:

```bash
./run_odoo.sh -i dms_field_file_description_preview,dms_ui_enhancements_file_description_preview -u dms_file_description --test-enable --test-tags /dms_file_description --log-level=test