### PR TITLE
[FIX] dms: use _slugify for subject in directory message_new

### DIFF
--- a/dms/models/directory.py
+++ b/dms/models/directory.py
@@ -625,8 +625,8 @@ class DmsDirectory(models.Model):
             parent_directory._process_message(msg_dict)
             return parent_directory
         names = parent_directory.child_directory_ids.mapped("name")
-        slug = self.env["ir.http"]._slug
-        subject = slug(msg_dict.get("subject", _("Alias-Mail-Extraction")))
+        slugify = self.env["ir.http"]._slugify
+        subject = slugify(msg_dict.get("subject", _("Alias-Mail-Extraction")))
         defaults = dict(
             {"name": unique_name(subject, names, escape_suffix=True)}, **custom_values
         )


### PR DESCRIPTION
Fixes #491.

## Problem

Incoming emails routed to a `dms.directory` alias configured with **Unpack Emails as: Subdirectory** (`alias_process = 'directory'`, the default) crash in `message_new`:

```
ValueError: too many values to unpack (expected 2)
```

`message_new` calls `ir.http._slug()` on the **subject string**, but `_slug()` expects a recordset or a `(id, name)` tuple, not a plain string.

## Fix

Use `ir.http._slugify()` — the helper meant to slugify a plain string — to build the subdirectory name from the email subject.

## Test

Verified manually: routing an email (with an attachment) to the directory alias now creates the expected subdirectory, named after the slugified subject, with the attachment stored as a `dms.file`. Happy to add an automated regression test under `dms/tests/` if reviewers prefer.
