### PR TITLE
[18.0][FIX] dms_field: Define the appropriate domain by filtering by res_model

### DIFF
--- a/dms_field/static/src/views/dms_list/dms_list_controller.esm.js
+++ b/dms_field/static/src/views/dms_list/dms_list_controller.esm.js
@@ -440,7 +440,10 @@ export function getDMSListControllerObject() {
             if (autocompute_directory) {
                 result = Domain.and([
                     result,
-                    new Domain([["res_id", "=", this.model.root.resId]]),
+                    new Domain([
+                        ["res_id", "=", this.model.root.resId],
+                        ["res_model", "=", this.resModel],
+                    ]),
                 ]);
             } else {
                 result = Domain.and([result, new Domain(domain || [])]);


### PR DESCRIPTION
Define the appropriate domain by filtering by res_model

Related to https://github.com/OCA/dms/issues/494 (Bug 2)

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa