### PR TITLE
[18.0][IMP] dms_field: Set the group_ids field as required if there is no parent directory

### DIFF
--- a/dms_field/views/dms_field_template_views.xml
+++ b/dms_field/views/dms_field_template_views.xml
@@ -35,7 +35,11 @@
                             invisible="not model_id"
                             required="1"
                         />
-                        <field name="group_ids" widget="many2many_tags" />
+                        <field
+                            name="group_ids"
+                            widget="many2many_tags"
+                            required="not parent_directory_id"
+                        />
                     </group>
                     <notebook position="inside">
                         <page


### PR DESCRIPTION
Set the `group_ids` field as required if there is no parent directory

Related to https://github.com/OCA/dms/issues/494 (Bug 4)

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa