### PR TITLE
[18.0][FIX] dms_field: make template root directory creation idempotent

### DIFF
--- a/dms_field/models/dms_field_template.py
+++ b/dms_field/models/dms_field_template.py
@@ -79,6 +79,27 @@ class DmsFieldTemplate(models.Model):
         record = self.env[res_model].browse(res_id)
         directory_model = self.env["dms.directory"].sudo()
         if res_model == "dms.field.template":
+            existing_directory = directory_model.search(
+                [
+                    ("storage_id", "=", record.storage_id.id),
+                    ("res_id", "=", record.id),
+                    ("res_model", "=", record._name),
+                    ("is_root_directory", "=", True),
+                ],
+                limit=1,
+            )
+            if existing_directory:
+                missing_groups = record.group_ids - existing_directory.group_ids
+                if missing_groups:
+                    existing_directory.write(
+                        {
+                            "group_ids": [
+                                fields.Command.link(group.id)
+                                for group in missing_groups
+                            ],
+                        }
+                    )
+                return existing_directory
             return directory_model.create(
                 {
                     "storage_id": record.storage_id.id,
@@ -86,7 +107,9 @@ class DmsFieldTemplate(models.Model):
                     "res_model": record._name,
                     "is_root_directory": True,
                     "name": record.display_name,
-                    "group_ids": record.group_ids.ids,
+                    "group_ids": [
+                        fields.Command.link(group.id) for group in record.group_ids
+                    ],
                 }
             )
         template = self._get_template_from_model(res_model).sudo()

--- a/dms_field/static/src/views/dms_list/dms_list_controller.esm.js
+++ b/dms_field/static/src/views/dms_list/dms_list_controller.esm.js
@@ -78,19 +78,22 @@ export function getDMSListControllerObject() {
                 directory_domain = [];
             } else if (model === "dms.field.template") {
                 if (this.model.root.resId) {
-                    storage_domain = [["id", "=", this.model.root.data.storage_id[0]]];
-                } else {
-                    storage_domain = [["id", "=", 0]];
-                }
-                directory_domain = [
-                    [
-                        "root_directory_id",
-                        "in",
+                    const rootDirectoryIds =
                         this.model.root.data.dms_directory_ids.records.map((record) => {
                             return record.resId;
-                        }),
-                    ],
-                ];
+                        });
+                    storage_domain = [["id", "=", this.model.root.data.storage_id[0]]];
+                    directory_domain = Domain.or([
+                        new Domain([["root_directory_id", "in", rootDirectoryIds]]),
+                        new Domain([
+                            ["res_model", "=", model],
+                            ["res_id", "=", this.model.root.resId],
+                        ]),
+                    ]).toList();
+                } else {
+                    storage_domain = [["id", "=", 0]];
+                    directory_domain = [["id", "=", 0]];
+                }
             } else {
                 storage_domain = [["field_template_ids.model", "=", model]];
                 autocompute_directory = true;

--- a/dms_field/tests/test_dms_field.py
+++ b/dms_field/tests/test_dms_field.py
@@ -118,6 +118,47 @@ class TestDmsField(BaseCommon):
             self.template.group_ids, self.template.dms_directory_ids.group_ids
         )
 
+    def test_template_directory_creation(self):
+        template = self.env["dms.field.template"].create(
+            {
+                "name": "Users template",
+                "storage_id": self.storage.id,
+                "model_id": self.env.ref("base.model_res_users").id,
+                "group_ids": [fields.Command.link(self.template.group_ids.id)],
+            }
+        )
+        directory = template.with_context(
+            res_model=template._name,
+            res_id=template.id,
+        ).create_dms_directory()
+
+        self.assertEqual(directory.storage_id, template.storage_id)
+        self.assertEqual(directory.res_model, template._name)
+        self.assertEqual(directory.res_id, template.id)
+        self.assertTrue(directory.is_root_directory)
+        self.assertIn(template.group_ids, directory.group_ids)
+        second_directory = template.with_context(
+            res_model=template._name,
+            res_id=template.id,
+        ).create_dms_directory()
+        self.assertEqual(second_directory, directory)
+
+    def test_template_directory_creation_is_idempotent(self):
+        directory = self.template.dms_directory_ids
+        directory.group_ids = [fields.Command.clear()]
+        self.assertFalse(directory.group_ids)
+
+        template = self.env["dms.field.template"].with_context(
+            res_model=self.template._name,
+            res_id=self.template.id,
+        )
+        first_directory = template.create_dms_directory()
+        second_directory = template.create_dms_directory()
+
+        self.assertEqual(first_directory, directory)
+        self.assertEqual(second_directory, directory)
+        self.assertIn(self.template.group_ids, directory.group_ids)
+
     @mute_logger("odoo.models.unlink")
     def test_creation_process_01(self):
         self.assertFalse(self.partner.dms_directory_ids)


### PR DESCRIPTION
Issue: https://github.com/OCA/dms/issues/500
Changed files:
- dms_field/models/dms_field_template.py
- dms_field/static/src/views/dms_list/dms_list_controller.esm.js

Root cause:
When initializing the Documents tab of a dms.field.template, the backend created the template root directory, but repeated calls to create_dms_directory() could try to create the same root again, causing:

"A directory with the same name already exists."

The created directory could also be missing template access groups, making it invisible to regular users. On the frontend, the DMS widget relied on cached dms_directory_ids, so a newly created template root directory could exist in the database but not appear immediately in the tree.

Solution:
Make dms.field.template root directory creation idempotent, keep access groups aligned with the template, and adjust the widget domain so the created root can be displayed after refresh.