### PR TITLE
[18.0][FIX] dms: Always b64encode contents from messages

### DIFF
--- a/dms/models/directory.py
+++ b/dms/models/directory.py
@@ -646,10 +646,9 @@ class DmsDirectory(models.Model):
                 "directory_id": self.id,
                 "name": uname,
             }
-            try:
-                vals["content"] = base64.b64encode(attachment.content)
-            except Exception:
-                vals["content"] = attachment.content
+            if isinstance(contents_raw := attachment.content, str):
+                contents_raw = contents_raw.encode()
+            vals["content"] = base64.b64encode(contents_raw)
             self.env["dms.file"].sudo().create(vals)
             names.append(uname)
 

--- a/dms/tests/test_directory.py
+++ b/dms/tests/test_directory.py
@@ -3,7 +3,7 @@
 # Copyright 2021-2022 Tecnativa - Víctor Martínez
 # Copyright 2024 Subteno - Timothée Vannier (https://www.subteno.com).
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
-
+import base64
 import os
 
 from odoo import Command
@@ -300,13 +300,14 @@ class DirectoryMailTestCase(StorageDatabaseBaseCase):
     @mute_logger("odoo.addons.mail.mail_thread")
     def test_mail_alias_files(self):
         self.directory.write({"alias_process": "files", "alias_name": "directory+test"})
-        self._handle_mail_reception()
-
-    def _handle_mail_reception(self):
         with open(os.path.join(_path, "tests", "data", "mail01.eml")) as file:
             self.env["mail.thread"].message_process(None, file.read())
         with open(os.path.join(_path, "tests", "data", "mail02.eml")) as file:
             self.env["mail.thread"].message_process(None, file.read())
+        # Check file created from mail02.eml further, ensure we can decode b64 contents.
+        dms_file = self.env["dms.file"].search([], limit=1, order="id desc")
+        self.assertEqual(dms_file.name, "bookmarks-really-short.html")
+        self.assertNotEqual(base64.b64decode(dms_file.content), dms_file.content)
 
     @mute_logger("odoo.addons.mail.mail_thread")
     def test_mail_alias_directory(self):


### PR DESCRIPTION
Previous implementation was failing to convert strings to base64, which is the case when we receive plain HTML encoded as base64; as shown in mail02.eml.

This in turn lead to inconsistencies when saving/reading these contents afterwards, as the rest of the code always assumes dms.file::content contains base64 data.

This was falling through cracks because although the resulting data is invalid base64, the b64decode impl in python 3.12/3.13 is lax enough it would ignore failures in this case because our test string is "base64-ish" enough.

However, when running Odoo on Debian with the patch https://sources.debian.org/patches/python3.13/3.13.5-2+deb13u3/CVE-2026-3446.patch/ applied, this test on mail02.eml produced errors in dms.file::_inverse_content when trying to b64decode:

> <class 'binascii.Error'> Invalid base64-encoded string: number of data characters (429) cannot be 1 more than a multiple of 4