### PR TITLE
[18.0][FIX] dms: Remove public read access to trigger redirect

### DIFF
--- a/dms/security/ir.model.access.csv
+++ b/dms/security/ir.model.access.csv
@@ -8,12 +8,10 @@ access_dms_storage_portal,dms_storage_portal,model_dms_storage,base.group_portal
 access_dms_storage_user,dms_storage_user,model_dms_storage,group_dms_user,1,0,0,0
 access_dms_storage_manager,dms_storage_manager,model_dms_storage,group_dms_manager,1,1,1,1
 
-access_dms_directory_public,dms_directory_public,model_dms_directory,base.group_public,1,0,0,0
 access_dms_directory_portal,dms_directory_portal,model_dms_directory,base.group_portal,1,0,0,0
 access_dms_directory_base_user,dms_directory_base_user,model_dms_directory,base.group_user,1,0,0,0
 access_dms_directory_user,dms_directory_user,model_dms_directory,group_dms_user,1,1,1,1
 
-access_dms_file_public,dms_file_public,model_dms_file,base.group_public,1,0,0,0
 access_dms_file_portal,dms_file_portal,model_dms_file,base.group_portal,1,0,0,0
 access_dms_file_base_user,dms_file_base_user,model_dms_file,base.group_user,1,0,0,0
 access_dms_file_user,dms_file_user,model_dms_file,group_dms_user,1,1,1,1


### PR DESCRIPTION
In order for the access-token to be processed and redirect to the proper url my/dms/directory... the user access must fail first here https://github.com/OCA/OCB/blob/18.0/addons/portal/controllers/mail.py#L155 otherwise you will be redirected to the login page even with the access token available, to test this:

1. Create a folder
2. Press share action
3. Try to enter the url without login
4. You will get redirected to the login, with this patch the folder content its properly displayed
@Tecnativa TT63966
@pedrobaeza @victoralmau 