### PR TITLE
[18.0][FIX] dms_field: Call the sanitizeDMSModel() method to obtain the appropriate model

### DIFF
--- a/dms_field/static/src/views/dms_list/dms_list_controller.esm.js
+++ b/dms_field/static/src/views/dms_list/dms_list_controller.esm.js
@@ -442,7 +442,7 @@ export function getDMSListControllerObject() {
                     result,
                     new Domain([
                         ["res_id", "=", this.model.root.resId],
-                        ["res_model", "=", this.resModel],
+                        ["res_model", "=", this.sanitizeDMSModel(this.resModel)],
                     ]),
                 ]);
             } else {


### PR DESCRIPTION
Call the `sanitizeDMSModel()` method to obtain the appropriate model

Use case example: `hr_dms_field`

Related to https://github.com/OCA/dms/pull/496

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT64085