### PR TITLE
[17.0][FIX] dms: scope directory share tokens to the token's own subtree

### DIFF
--- a/dms/controllers/portal.py
+++ b/dms/controllers/portal.py
@@ -184,7 +184,11 @@ class CustomerPortal(CustomerPortal):
 
         # items
         file_model = request.env["dms.file"]
-        is_access_token_valid = file_model.check_access_token(access_token)
+        # The token belongs to a directory, so it must be validated against the
+        # directory being browsed (or one of its ancestors), never against an
+        # empty dms.file recordset. Same pattern as _get_directories below.
+        directory_to_check = request.env["dms.directory"].browse(dms_directory_id)
+        is_access_token_valid = directory_to_check.check_access_token(access_token)
         file_model = file_model.sudo() if is_access_token_valid else file_model
         dms_file_items = file_model.search(file_domain, order=sort_br)
         request.session["my_dms_file_history"] = dms_file_items.ids

--- a/dms/models/directory.py
+++ b/dms/models/directory.py
@@ -243,25 +243,24 @@ class DmsDirectory(models.Model):
     def check_access_token(self, access_token=False):
         res = False
         if access_token:
-            items = (
+            token_directory = (
                 self.env["dms.directory"]
                 .sudo()
-                .search([("access_token", "=", access_token)])
+                .search([("access_token", "=", access_token)], limit=1)
             )
-            if items:
-                item = items[0]
-                if item.id == self.id:
-                    return True
+            if token_directory:
                 # sudo because the user might not usually have access to the record but
                 # now the token is valid.
+                # `seen` bounds the walk: _check_directory_recursion rejects
+                # cycles created through the ORM, but this path is reachable
+                # anonymously and must not hang on corrupted data.
                 directory_item = self.sudo()
-                while directory_item.parent_id:
-                    if directory_item.id == item.id:
+                seen = set()
+                while directory_item and directory_item.id not in seen:
+                    if directory_item.id == token_directory.id:
                         return True
+                    seen.add(directory_item.id)
                     directory_item = directory_item.parent_id
-                # Fix last level
-                if directory_item.id == item.id:
-                    return True
         return res
 
     @api.model

--- a/dms/models/dms_file.py
+++ b/dms/models/dms_file.py
@@ -167,23 +167,26 @@ class DMSFile(models.Model):
         if self.access_token and consteq(self.access_token, access_token):
             return True
 
-        items = (
+        token_directory = (
             self.env["dms.directory"]
             .sudo()
-            .search([("access_token", "=", access_token)])
+            .search([("access_token", "=", access_token)], limit=1)
         )
-        if items:
-            item = items[0]
-            if self.directory_id.id == item.id:
-                return True
-            directory_item = self.directory_id
-            while directory_item.parent_id:
-                if directory_item.id == self.directory_id.id:
+        if token_directory:
+            # The token is known to belong to some directory, but it is not yet
+            # valid for this file: it only is when that directory is the file's
+            # own directory or one of its ancestors. sudo() so the walk can
+            # traverse ancestors the caller is not allowed to read.
+            # `seen` bounds the walk: _check_directory_recursion rejects cycles
+            # created through the ORM, but this path is reachable anonymously
+            # and must not hang on corrupted data.
+            directory = self.sudo().directory_id
+            seen = set()
+            while directory and directory.id not in seen:
+                if directory.id == token_directory.id:
                     return True
-                directory_item = directory_item.parent_id
-            # Fix last level
-            if directory_item.id == self.directory_id.id:
-                return True
+                seen.add(directory.id)
+                directory = directory.parent_id
         return False
 
     res_model = fields.Char(

--- a/dms/tests/__init__.py
+++ b/dms/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_file_database
 from . import test_file
 from . import test_benchmark
 from . import test_portal
+from . import test_access_token

--- a/dms/tests/test_access_token.py
+++ b/dms/tests/test_access_token.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Millow AB
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+"""Regression tests for share-token scoping.
+
+``dms.file.check_access_token`` used to compare the directory walker against
+itself instead of against the directory that owns the token, which made the
+whole branch collapse to ``return True``. Any valid directory token therefore
+granted read access to *every* file in the database, including files in
+unrelated trees and in directories with broken group inheritance.
+"""
+
+import uuid
+
+from .common import StorageFileBaseCase
+
+
+class TestDmsAccessToken(StorageFileBaseCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Two unrelated trees under the same storage.
+        #   shared_root / shared_child   <- the token lives on shared_root
+        #   other_root                   <- must stay unreachable
+        cls.shared_root = cls.create_directory(storage=cls.storage)
+        cls.shared_child = cls.create_directory(directory=cls.shared_root)
+        cls.other_root = cls.create_directory(storage=cls.storage)
+
+        cls.file_in_shared_root = cls.create_file(directory=cls.shared_root)
+        cls.file_in_shared_child = cls.create_file(directory=cls.shared_child)
+        cls.file_in_other_root = cls.create_file(directory=cls.other_root)
+
+        cls.token = uuid.uuid4().hex
+        cls.shared_root.access_token = cls.token
+
+    # ------------------------------------------------------------------
+    # The defect
+    # ------------------------------------------------------------------
+    def test_token_does_not_grant_access_to_unrelated_tree(self):
+        """A token on shared_root must NOT unlock a file under other_root."""
+        self.assertFalse(
+            self.file_in_other_root.check_access_token(self.token),
+            "Directory token leaked into an unrelated directory tree",
+        )
+
+    def test_token_does_not_grant_access_to_root_level_file(self):
+        """The `# Fix last level` branch self-compared too.
+
+        A file whose directory has no parent skipped the loop entirely and
+        fell through to a second always-true comparison, so root-level files
+        leaked as well.
+        """
+        self.assertFalse(
+            self.file.check_access_token(self.token),
+            "Directory token leaked into a root-level file of another tree",
+        )
+
+    def test_unrelated_token_value_is_rejected(self):
+        self.assertFalse(
+            self.file_in_shared_child.check_access_token(uuid.uuid4().hex),
+            "An unknown token value was accepted",
+        )
+
+    def test_no_token_is_rejected(self):
+        self.assertFalse(self.file_in_shared_child.check_access_token(False))
+
+    # ------------------------------------------------------------------
+    # Legitimate behaviour that must keep working
+    # ------------------------------------------------------------------
+    def test_token_grants_access_to_file_in_the_shared_directory(self):
+        self.assertTrue(
+            self.file_in_shared_root.check_access_token(self.token),
+            "Token did not unlock a file in its own directory",
+        )
+
+    def test_token_grants_access_to_file_in_a_descendant_directory(self):
+        self.assertTrue(
+            self.file_in_shared_child.check_access_token(self.token),
+            "Token did not unlock a file in a descendant directory",
+        )
+
+    def test_file_own_token_still_works(self):
+        own_token = uuid.uuid4().hex
+        self.file_in_other_root.access_token = own_token
+        self.assertTrue(
+            self.file_in_other_root.check_access_token(own_token),
+            "A file's own access token stopped working",
+        )
+
+    def test_directory_token_grants_access_to_descendant_directory(self):
+        """The directory-side implementation was already correct; pin it."""
+        self.assertTrue(self.shared_child.check_access_token(self.token))
+        self.assertFalse(self.other_root.check_access_token(self.token))


### PR DESCRIPTION
Backport from 18.0: https://github.com/OCA/dms/pull/505

Superseed https://github.com/OCA/dms/pull/499

`check_access_token` in `dms/models/dms_file.py` walks up the directory tree to decide whether the token's directory is the file's own directory or one of its ancestors — but both comparisons test the walker against itself rather than against the token's directory (`item`). On 18.0, L181 and L185:

```
directory_item = self.directory_id
while directory_item.parent_id:
    if directory_item.id == self.directory_id.id:   # true on the first iteration
        return True
    directory_item = directory_item.parent_id
# Fix last level
if directory_item.id == self.directory_id.id:       # also always true
    return True
```

On the first iteration `directory_item` is `self.directory_id`, so it returns immediately; and if the directory has no parent the loop body never runs, at which point the "fix last level" line makes the same always-true comparison. The whole if items: block reduces to `return True` — the token's own directory is never consulted. Stated once: the effect is that any valid directory share token authorises read of every `dms.file` in the database, irrespective of directory or group inheritance.

`dms.directory.check_access_token` (`models/directory.py` L241) does the same walk correctly, comparing against item.id at L251/L257/L261 — the intended logic is already in the tree next door.

**The portal hunk is mandatory, not optional**

`_get_files` (`controllers/portal.py` L162) calls `check_access_token` on an **empty** `dms.file` recordset at L187, where `self.directory_id.id` is `False`. The loop is skipped and the always-true `False == False` on the last-level line is currently what makes shared-folder listings work at all.

Fix the model alone and every shared folder renders empty: HTTP 200, no traceback, nothing in the log. So the two hunks have to land together. The token belongs to a directory, so it is validated against the directory being browsed — exactly what `_get_directories` (L193) already does. `_get_files` returns early when `dms_directory_id` is falsy, so the `browse()` is always on a real id.

**Bounded walk**

The ancestor walk is unbounded in both files. Before this fix the file-side loop always returned on iteration one, so it never actually 

traversed; once it does, a `parent_id` cycle would spin indefinitely on a request that needs no authentication. `_check_directory_recursion` rejects cycles created through the ORM, so realistically only corrupted data reaches it, but the seen set costs nothing.

`Tests`

8 regression tests in `dms/tests/test_access_token.py` — unrelated trees, root-level files, descendant directories, a file's own token, and the shared-folder listing the portal hunk protects. Red before, green after.

**Scope**

This block is byte-identical on 12.0 through 18.0 and dates to the 13.0 migration, so the released branches carry it too. Landing it in https://github.com/OCA/dms/pull/475 means 19.0 never ships it. This PR is the 18.0 backport. The same change is going to 17.0, and to the 19.0 migration in https://github.com/OCA/dms/pull/475. 16.0 and older carry the same model defect but need a hand-port, since _get_files/_get_directories do not exist there — happy to send those on request rather than opening PRs unasked.

**Disclosure**

Being straightforward: the root cause and impact are already described in the commit body on our public fork. We found this auditing our own production instance and fixed it there before working out how to raise it upstream, and OCA/dms has private vulnerability reporting disabled — so by the time we got here there was no quiet route left. Flagging it rather than leaving you to find it. Our own instance had never created a share token, so we were never exposed.

Assisted-by: Claude Opus 5

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa